### PR TITLE
Add K8s secret support for database credentials

### DIFF
--- a/charts/extractor/templates/_environment.tpl
+++ b/charts/extractor/templates/_environment.tpl
@@ -1,9 +1,16 @@
 {{/*
 Facture pods are configured primarily through the environment. Environment variables
-are set and defined here using configuration values from the values.yaml file.
+are set and defined here using configuration values from the values.yaml file or K8s secrets.
 */}}
 {{- define "extractor.environment" -}}
 env:
   - name: DATABASE_URL
+    {{- if .Values.extractor.databaseURL }}
     value: {{ .Values.extractor.databaseURL | quote }}
+    {{- else }}
+    valueFrom:
+      secretKeyRef:
+        name: facture-db-credentials
+        key: database-url
+    {{- end }}
 {{- end -}}

--- a/charts/lander/templates/_environment.tpl
+++ b/charts/lander/templates/_environment.tpl
@@ -1,9 +1,16 @@
 {{/*
 Facture pods are configured primarily through the environment. Environment variables
-are set and defined here using configuration values from the values.yaml file.
+are set and defined here using configuration values from the values.yaml file or K8s secrets.
 */}}
 {{- define "lander.environment" -}}
 env:
   - name: DATABASE_URL
+    {{- if .Values.lander.databaseURL }}
     value: {{ .Values.lander.databaseURL | quote }}
+    {{- else }}
+    valueFrom:
+      secretKeyRef:
+        name: facture-db-credentials
+        key: database-url
+    {{- end }}
 {{- end -}}

--- a/charts/worker/templates/_environment.tpl
+++ b/charts/worker/templates/_environment.tpl
@@ -1,9 +1,16 @@
 {{/*
 Facture pods are configured primarily through the environment. Environment variables
-are set and defined here using configuration values from the values.yaml file.
+are set and defined here using configuration values from the values.yaml file or K8s secrets.
 */}}
 {{- define "worker.environment" -}}
 env:
   - name: DATABASE_URL
+    {{- if .Values.worker.databaseURL }}
     value: {{ .Values.worker.databaseURL | quote }}
+    {{- else }}
+    valueFrom:
+      secretKeyRef:
+        name: facture-db-credentials
+        key: database-url
+    {{- end }}
 {{- end -}}


### PR DESCRIPTION
Allow charts to read DATABASE_URL from K8s secret when not provided via values.

- Defaults to K8s secret (facture-db-credentials)
- Falls back to values if provided (backwards compatible)
- All three services updated (lander, worker, extractor)

### Scope of changes

Updated the charts for each of the services to use k8 secrets

### Type of change

- [ ] update app version
- [ ] new objects/feature
- [x] new/additional configuration
- [ ] documentation
- [ ] other (describe)

### Author checklist

- [ ] I have manually debugged the charts using `helm debug`
- [ ] I have updated any affected `values.schema.json` files
- [ ] I have updated the Chart Version for any affected charts
