### PR TITLE
Add IRSA service account support

### DIFF
--- a/charts/extractor/Chart.yaml
+++ b/charts/extractor/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/extractor/templates/_helpers.tpl
+++ b/charts/extractor/templates/_helpers.tpl
@@ -57,3 +57,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{ default (include "extractor.fullname" .) .Values.secrets.databaseURL.name }}
 {{- end -}}
 {{- end -}}
+
+{{- define "extractor.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ .Values.serviceAccount.name | default (include "extractor.fullname" .) }}
+{{- else -}}
+default
+{{- end -}}
+{{- end -}}

--- a/charts/extractor/templates/deployment.yaml
+++ b/charts/extractor/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      serviceAccountName: {{ include "extractor.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/extractor/templates/serviceaccount.yaml
+++ b/charts/extractor/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name | default (include "extractor.fullname" .) }}
+  labels:
+    {{- include "extractor.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/extractor/values.yaml
+++ b/charts/extractor/values.yaml
@@ -13,6 +13,12 @@ replicaCount: 1
 
 extractor: {}
 
+# Service account for IRSA (IAM Roles for Service Accounts)
+serviceAccount:
+  create: true
+  name: ""  # If empty, uses the fullname
+  annotations: {}  # Add eks.amazonaws.com/role-arn annotation via helmfile
+
 secrets:
   create: false
   databaseURL:

--- a/charts/lander/Chart.yaml
+++ b/charts/lander/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lander/templates/_helpers.tpl
+++ b/charts/lander/templates/_helpers.tpl
@@ -57,3 +57,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{ default (include "lander.fullname" .) .Values.secrets.databaseURL.name }}
 {{- end -}}
 {{- end -}}
+
+{{- define "lander.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ .Values.serviceAccount.name | default (include "lander.fullname" .) }}
+{{- else -}}
+default
+{{- end -}}
+{{- end -}}

--- a/charts/lander/templates/deployment.yaml
+++ b/charts/lander/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      serviceAccountName: {{ include "lander.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/lander/templates/serviceaccount.yaml
+++ b/charts/lander/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name | default (include "lander.fullname" .) }}
+  labels:
+    {{- include "lander.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/lander/values.yaml
+++ b/charts/lander/values.yaml
@@ -13,6 +13,12 @@ replicaCount: 1
 
 lander: {}
 
+# Service account for IRSA (IAM Roles for Service Accounts)
+serviceAccount:
+  create: true
+  name: ""  # If empty, uses the fullname
+  annotations: {}  # Add eks.amazonaws.com/role-arn annotation via helmfile
+
 secrets:
   create: false
   databaseURL:

--- a/charts/worker/Chart.yaml
+++ b/charts/worker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/worker/templates/_helpers.tpl
+++ b/charts/worker/templates/_helpers.tpl
@@ -57,3 +57,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{ default (include "worker.fullname" .) .Values.secrets.databaseURL.name }}
 {{- end -}}
 {{- end -}}
+
+{{- define "worker.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ .Values.serviceAccount.name | default (include "worker.fullname" .) }}
+{{- else -}}
+default
+{{- end -}}
+{{- end -}}

--- a/charts/worker/templates/deployment.yaml
+++ b/charts/worker/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      serviceAccountName: {{ include "worker.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/worker/templates/serviceaccount.yaml
+++ b/charts/worker/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name | default (include "worker.fullname" .) }}
+  labels:
+    {{- include "worker.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/worker/values.yaml
+++ b/charts/worker/values.yaml
@@ -13,6 +13,12 @@ replicaCount: 1
 
 worker: {}
 
+# Service account for IRSA (IAM Roles for Service Accounts)
+serviceAccount:
+  create: true
+  name: ""  # If empty, uses the fullname
+  annotations: {}  # Add eks.amazonaws.com/role-arn annotation via helmfile
+
 secrets:
   create: false
   databaseURL:


### PR DESCRIPTION
### Scope of changes

All three charts (lander, worker, extractor) have been modified to support IAM Roles for Service Accounts (IRSA):

- Added `serviceAccount` configuration block to values.yaml
- Created serviceaccount.yaml templates with annotation support
- Added `serviceAccountName` helper to _helpers.tpl
- Updated deployment.yaml to reference serviceAccountName
- Bumped chart versions from 0.2.1 to 0.2.2

This enables pods to assume IAM roles via EKS OIDC provider without requiring explicit AWS credentials.

### Type of change

- [ ] update app version
- [x] new objects/feature
- [x] new/additional configuration
- [ ] documentation
- [ ] other (describe)

### Author checklist

- [x] I have manually debugged the charts using `helm debug`
- [ ] I have updated any affected `values.schema.json` files
- [x] I have updated the Chart Version for any affected charts