### PR TITLE
Add Recreate deployment strategy to extractor chart

### DIFF
--- a/charts/extractor/Chart.yaml
+++ b/charts/extractor/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/extractor/templates/deployment.yaml
+++ b/charts/extractor/templates/deployment.yaml
@@ -6,6 +6,13 @@ metadata:
     {{- include "extractor.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
+    {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.updateStrategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.updateStrategy.rollingUpdate.maxUnavailable }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "extractor.selectorLabels" . | nindent 6 }}

--- a/charts/extractor/values.yaml
+++ b/charts/extractor/values.yaml
@@ -11,6 +11,12 @@ fullnameOverride: ""
 
 replicaCount: 1
 
+# Deployment update strategy
+# Recreate: terminates old pod before starting new one (required for GPU services on single-node clusters)
+# RollingUpdate: starts new pod before terminating old one (zero downtime but requires extra capacity)
+updateStrategy:
+  type: Recreate
+
 extractor: {}
 
 # AWS configuration


### PR DESCRIPTION
## Changes
- Add configurable `updateStrategy` to extractor deployment template
- Set default to `Recreate` for extractor chart
- Bump chart version to 0.2.4

## Problem
Extractor deployments deadlock on single node clusters due to RollingUpdate attempting to run 2 pods simultaneously.

## Solution
Use Recreate strategy which terminates old pod before starting new one.

## Testing
- Helm lint passes
- Template renders correctly with `strategy.type: Recreate`
- Will verify with deployment update after publish

Fixes #7