### PR TITLE
Sync service charts to v0.6.1

### DIFF
--- a/charts/extractor/Chart.yaml
+++ b/charts/extractor/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.0"
+appVersion: "0.6.1"
 
 # Project Information
 home: https://kungfu.ai

--- a/charts/extractor/README.md
+++ b/charts/extractor/README.md
@@ -3,8 +3,11 @@
 Create a minimal `values.yaml` file:
 
 ```yaml
-facture:
-    databaseURL: postgres://localhost:5432/facture
+aws:
+  s3Bucket: my-bucket
+secrets:
+  databaseURL:
+    value: postgres://localhost:5432/facture
 ```
 
 Update the helm repo and install the extractor:

--- a/charts/extractor/templates/_environment.tpl
+++ b/charts/extractor/templates/_environment.tpl
@@ -17,11 +17,4 @@ env:
       secretKeyRef:
         name: {{ include "extractor.databaseURLSecretName" . }}
         key: {{ .Values.secrets.databaseURL.key }}
-  {{- if .Values.secrets.anthropicAPIKey.enabled }}
-  - name: ANTHROPIC_API_KEY
-    valueFrom:
-      secretKeyRef:
-        name: {{ include "extractor.anthropicAPIKeySecretName" . }}
-        key: {{ .Values.secrets.anthropicAPIKey.key }}
-  {{- end }}
 {{- end -}}

--- a/charts/extractor/templates/_helpers.tpl
+++ b/charts/extractor/templates/_helpers.tpl
@@ -58,15 +58,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
-{{- define "extractor.anthropicAPIKeySecretName" -}}
-{{- if .Values.secrets.create -}}
-{{ include "extractor.fullname" . }}
-{{- else -}}
-{{ default (include "extractor.fullname" .) .Values.secrets.anthropicAPIKey.name }}
-{{- end -}}
-{{- end -}}
-
-
 {{- define "extractor.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
 {{ .Values.serviceAccount.name | default (include "extractor.fullname" .) }}

--- a/charts/extractor/templates/secret.yaml
+++ b/charts/extractor/templates/secret.yaml
@@ -9,7 +9,4 @@ data:
   {{- if .Values.secrets.databaseURL.value }}
   {{ .Values.secrets.databaseURL.key }}: {{ .Values.secrets.databaseURL.value | b64enc }}
   {{- end }}
-  {{- if .Values.secrets.anthropicAPIKey.value }}
-  {{ .Values.secrets.anthropicAPIKey.key }}: {{ .Values.secrets.anthropicAPIKey.value | b64enc }}
-  {{- end }}
 {{- end }}

--- a/charts/extractor/values.yaml
+++ b/charts/extractor/values.yaml
@@ -37,11 +37,6 @@ secrets:
     name: ""
     key: "database-url"
     value: ""
-  anthropicAPIKey:
-    enabled: false
-    name: ""
-    key: "anthropic-api-key"
-    value: ""
 
 image:
   repository: 595425361112.dkr.ecr.us-east-2.amazonaws.com/facture-extractor

--- a/charts/lander/Chart.yaml
+++ b/charts/lander/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.0"
+appVersion: "0.6.1"
 
 # Project Information
 home: https://kungfu.ai

--- a/charts/lander/README.md
+++ b/charts/lander/README.md
@@ -3,8 +3,11 @@
 Create a minimal `values.yaml` file:
 
 ```yaml
-facture:
-    databaseURL: postgres://localhost:5432/facture
+aws:
+  s3Bucket: my-bucket
+secrets:
+  databaseURL:
+    value: postgres://localhost:5432/facture
 ```
 
 Update the helm repo and install the lander:

--- a/charts/lander/templates/jobs.yaml
+++ b/charts/lander/templates/jobs.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.jobs.migrate.create -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "lander.fullname" . }}-migrate
+  labels:
+    {{- include "lander.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "8"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ include "lander.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.pod.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: [ "/bin/sh", "-c" ]
+          args:
+            - "python -m alembic upgrade head"
+          {{- include "lander.environment" . | nindent 10 }}
+      restartPolicy: Never
+  backoffLimit: {{ .Values.jobs.migrate.backoffLimit | default 5 }}
+{{- end -}}

--- a/charts/lander/values.yaml
+++ b/charts/lander/values.yaml
@@ -39,6 +39,11 @@ secrets:
     key: "database-url"
     value: ""
 
+jobs:
+  migrate:
+    create: true
+    backoffLimit: 3
+
 image:
   repository: 595425361112.dkr.ecr.us-east-2.amazonaws.com/facture-lander
   pullPolicy: Always                 # Specify image pull policy (Always, IfNotPresent, Never).

--- a/charts/worker/Chart.yaml
+++ b/charts/worker/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.0"
+appVersion: "0.6.1"
 
 # Project Information
 home: https://kungfu.ai

--- a/charts/worker/README.md
+++ b/charts/worker/README.md
@@ -3,8 +3,11 @@
 Create a minimal `values.yaml` file:
 
 ```yaml
-facture:
-    databaseURL: postgres://localhost:5432/facture
+aws:
+  s3Bucket: my-bucket
+secrets:
+  databaseURL:
+    value: postgres://localhost:5432/facture
 ```
 
 Update the helm repo and install the worker:

--- a/charts/worker/values.yaml
+++ b/charts/worker/values.yaml
@@ -12,7 +12,7 @@ fullnameOverride: ""
 replicaCount: 1
 
 worker:
-  extractorConfig: /home/worker/app/extractor.json
+  extractorConfig: /home/worker/app/config/extractor.json
 
 # AWS configuration
 aws:


### PR DESCRIPTION
### Scope of changes

Sync lander, worker, and extractor charts from gcio-irs-tax-form-processor to v0.6.1:

**lander:**
- Add `templates/jobs.yaml` for database migrate job with helm hooks
- Add `jobs:` configuration in values.yaml
- Bump version 0.3.0 → 0.6.1

**worker:**
- Fix `extractorConfig` path to `config/extractor.json`
- Bump version 0.3.0 → 0.6.1

**extractor:**
- Update templates (_environment.tpl, _helpers.tpl, secret.yaml)
- Remove unused `anthropicAPIKey` config (using Bedrock/IRSA)
- Bump version 0.3.0 → 0.6.1

### Type of change

- [x] update app version
- [x] new objects/feature
- [x] new/additional configuration
- [ ] documentation
- [ ] other (describe)

### Author checklist

- [x] I have manually debugged the charts using `helm debug`
- [ ] I have updated any affected `values.schema.json` files
- [x] I have updated the Chart Version for any affected charts