### PR TITLE
Add infrastructure charts for JupyterHub platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,15 @@ facture` to see the charts.
 
 ## Available Charts
 
-- [Lander](charts/lander/README.md)
-- [Worker](charts/worker/README.md)
-- [Extractor](charts/extractor/README.md)
+### Application Charts
+- [Lander](charts/lander/README.md) - HTTP API for document ingestion
+- [Worker](charts/worker/README.md) - Document processing pipeline orchestrator
+- [Extractor](charts/extractor/README.md) - GPU/LLM inference service
+
+### Infrastructure Charts
+- `jupyterhub-rbac` - RBAC configuration for JupyterHub notebook pods
+- `karpenter-nodepools` - Karpenter NodePool and EC2NodeClass configurations
+- `nvidia-device-plugin` - NVIDIA GPU device plugin for Kubernetes
 
 ## Debugging Templates
 

--- a/charts/jupyterhub-rbac/Chart.yaml
+++ b/charts/jupyterhub-rbac/Chart.yaml
@@ -1,0 +1,33 @@
+apiVersion: v2
+name: jupyterhub-rbac
+description: RBAC configuration for JupyterHub user notebooks with AWS IRSA integration.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"
+
+# Project Information
+home: https://kungfu.ai
+icon: https://cdn.prod.website-files.com/626ff088dc91e832fe2f3249/680e74ec5378b7b440b03b0c_32x32.png
+sources:
+  - https://github.com/kungfuai/gcio-irs-helm-charts
+maintainers:
+  - name: KungFu.ai
+    email: daas-support@kungfu.ai

--- a/charts/jupyterhub-rbac/templates/role.yaml
+++ b/charts/jupyterhub-rbac/templates/role.yaml
@@ -1,0 +1,7 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.serviceAccountName }}
+  namespace: {{ .Values.namespace }}
+rules:
+  {{- toYaml .Values.roleRules | nindent 2 }}

--- a/charts/jupyterhub-rbac/templates/rolebinding.yaml
+++ b/charts/jupyterhub-rbac/templates/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.serviceAccountName }}
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Values.serviceAccountName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccountName }}
+    namespace: {{ .Values.namespace }}

--- a/charts/jupyterhub-rbac/templates/serviceaccount.yaml
+++ b/charts/jupyterhub-rbac/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccountName }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.irsaRoleArn }}

--- a/charts/jupyterhub-rbac/values.yaml
+++ b/charts/jupyterhub-rbac/values.yaml
@@ -1,0 +1,16 @@
+# JupyterHub RBAC Configuration
+
+# Namespace where JupyterHub is deployed
+namespace: jupyter
+
+# ServiceAccount name (referenced by JupyterHub singleuser pods)
+serviceAccountName: jupyterhub-user
+
+# IAM role ARN for IRSA (passed from helmfile)
+irsaRoleArn: ""
+
+# Role permissions for notebook pods
+roleRules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "services", "persistentvolumeclaims", "events"]
+    verbs: ["get", "list", "watch", "create", "delete"]

--- a/charts/karpenter-nodepools/Chart.yaml
+++ b/charts/karpenter-nodepools/Chart.yaml
@@ -1,0 +1,33 @@
+apiVersion: v2
+name: karpenter-nodepools
+description: Karpenter NodePools and EC2NodeClass configuration for dynamic node provisioning.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"
+
+# Project Information
+home: https://kungfu.ai
+icon: https://cdn.prod.website-files.com/626ff088dc91e832fe2f3249/680e74ec5378b7b440b03b0c_32x32.png
+sources:
+  - https://github.com/kungfuai/gcio-irs-helm-charts
+maintainers:
+  - name: KungFu.ai
+    email: daas-support@kungfu.ai

--- a/charts/karpenter-nodepools/templates/ec2nodeclass-default.yaml
+++ b/charts/karpenter-nodepools/templates/ec2nodeclass-default.yaml
@@ -1,0 +1,54 @@
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: default
+spec:
+  # Use EKS optimized AMI (includes NVIDIA drivers for GPU instances)
+  amiSelectorTerms:
+    - alias: al2023@latest
+
+  # IAM instance profile for nodes (created by Terraform)
+  instanceProfile: {{ .Values.nodeInstanceProfileName }}
+
+  # Subnets - discover using cluster name tag
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: {{ .Values.clusterName }}
+
+  # Security groups - use cluster security group
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: {{ .Values.clusterName }}
+
+  # User data for node initialization (AL2023 uses nodeadm, Karpenter handles cluster config automatically)
+  # Leave empty or specify custom NodeConfig settings if needed
+  # userData: |
+  #   apiVersion: node.eks.aws/v1alpha1
+  #   kind: NodeConfig
+  #   spec:
+  #     kubelet:
+  #       config:
+  #         maxPods: 110
+
+  # Tags for EC2 instances
+  tags:
+    Name: karpenter-node
+    Environment: experimental
+    ManagedBy: Karpenter
+    Project: kfai-facture
+
+  # Block device configuration
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        volumeSize: 100Gi
+        volumeType: gp3
+        encrypted: true
+        deleteOnTermination: true
+
+  # IMDSv2 required for security
+  metadataOptions:
+    httpEndpoint: enabled
+    httpProtocolIPv6: disabled
+    httpPutResponseHopLimit: 2
+    httpTokens: required

--- a/charts/karpenter-nodepools/templates/nodepool-jupyter-cpu.yaml
+++ b/charts/karpenter-nodepools/templates/nodepool-jupyter-cpu.yaml
@@ -1,0 +1,44 @@
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: jupyter-cpu
+spec:
+  # Template for nodes created by this pool
+  template:
+    metadata:
+      labels:
+        workload: jupyter
+        type: cpu
+    spec:
+      # Node class to use
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: default
+
+      # Requirements for instance selection
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]  # Use spot for cost savings if desired
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["t", "c", "m"]  # General purpose and compute optimized
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["4"]  # Gen 5 and newer
+
+  # Limits for this pool
+  limits:
+    cpu: 100    # Max 100 CPUs across all nodes in this pool
+    memory: 200Gi
+
+  # Disruption settings
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 1m
+    budgets:
+      - nodes: "10%"

--- a/charts/karpenter-nodepools/templates/nodepool-jupyter-gpu.yaml
+++ b/charts/karpenter-nodepools/templates/nodepool-jupyter-gpu.yaml
@@ -1,0 +1,51 @@
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: jupyter-gpu
+spec:
+  # Template for nodes created by this pool
+  template:
+    metadata:
+      labels:
+        workload: jupyter
+        type: gpu
+    spec:
+      # Node class to use
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: default
+
+      # Taints to prevent non-GPU workloads from scheduling here
+      taints:
+        - key: nvidia.com/gpu
+          value: "true"
+          effect: NoSchedule
+
+      # Requirements for instance selection
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]  # GPU instances - use on-demand for stability
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: karpenter.k8s.aws/instance-family
+          operator: In
+          values: ["g4dn", "g5"]  # NVIDIA GPU instance families
+        - key: karpenter.k8s.aws/instance-size
+          operator: In
+          values: ["xlarge", "2xlarge", "4xlarge", "8xlarge", "12xlarge", "16xlarge"]  # Support multi-GPU instances
+
+  # Limits for this pool (GPUs are expensive!)
+  limits:
+    cpu: 128       # Max CPUs (multi-GPU instances have many cores)
+    memory: 512Gi  # Max memory
+    nvidia.com/gpu: 16  # Max 16 GPUs across all nodes
+
+  # Disruption settings - be careful with GPU workloads
+  disruption:
+    consolidationPolicy: WhenEmpty  # Only consolidate when completely empty
+    consolidateAfter: 5m  # Wait 5 min before removing empty nodes
+    budgets:
+      - nodes: "1"  # Only disrupt 1 node at a time

--- a/charts/karpenter-nodepools/templates/nodepool-services-cpu.yaml
+++ b/charts/karpenter-nodepools/templates/nodepool-services-cpu.yaml
@@ -1,0 +1,44 @@
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: services-cpu
+spec:
+  # Template for nodes created by this pool
+  template:
+    metadata:
+      labels:
+        workload: services
+        type: cpu
+    spec:
+      # Node class to use
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: default
+
+      # Requirements for instance selection
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]  # Use on-demand for service reliability
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["t", "m"]  # General purpose instances
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["4"]  # Gen 5 and newer
+
+  # Limits for this pool
+  limits:
+    cpu: 50
+    memory: 100Gi
+
+  # Disruption settings
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 2m  # Services can tolerate quicker consolidation
+    budgets:
+      - nodes: "10%"

--- a/charts/karpenter-nodepools/templates/nodepool-services-gpu.yaml
+++ b/charts/karpenter-nodepools/templates/nodepool-services-gpu.yaml
@@ -1,0 +1,51 @@
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: services-gpu
+spec:
+  # Template for nodes created by this pool
+  template:
+    metadata:
+      labels:
+        workload: services
+        type: gpu
+    spec:
+      # Node class to use
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: default
+
+      # Taints to prevent non-GPU workloads from scheduling here
+      taints:
+        - key: nvidia.com/gpu
+          value: "true"
+          effect: NoSchedule
+
+      # Requirements for instance selection
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]  # Services need on-demand reliability
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: karpenter.k8s.aws/instance-family
+          operator: In
+          values: ["g4dn", "g5"]  # T4 and A10G GPUs
+        - key: karpenter.k8s.aws/instance-size
+          operator: In
+          values: ["xlarge", "2xlarge"]  # Control instance size
+
+  # Limits for this pool
+  limits:
+    cpu: 32
+    memory: 128Gi
+    nvidia.com/gpu: 4  # Max 4 GPUs for services
+
+  # Disruption settings - conservative for production services
+  disruption:
+    consolidationPolicy: WhenEmpty  # Only when completely empty
+    consolidateAfter: 10m  # Wait 10 min to ensure service stability
+    budgets:
+      - nodes: "1"  # Only disrupt 1 node at a time

--- a/charts/nvidia-device-plugin/Chart.yaml
+++ b/charts/nvidia-device-plugin/Chart.yaml
@@ -1,0 +1,33 @@
+apiVersion: v2
+name: nvidia-device-plugin
+description: NVIDIA device plugin DaemonSet for GPU node support in Kubernetes.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.16.2"
+
+# Project Information
+home: https://kungfu.ai
+icon: https://cdn.prod.website-files.com/626ff088dc91e832fe2f3249/680e74ec5378b7b440b03b0c_32x32.png
+sources:
+  - https://github.com/kungfuai/gcio-irs-helm-charts
+maintainers:
+  - name: KungFu.ai
+    email: daas-support@kungfu.ai

--- a/charts/nvidia-device-plugin/templates/daemonset.yaml
+++ b/charts/nvidia-device-plugin/templates/daemonset.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-device-plugin-daemonset
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: nvidia-device-plugin-ds
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: nvidia-device-plugin-ds
+    spec:
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      containers:
+      - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        name: nvidia-device-plugin-ctr
+        args:
+          - "--fail-on-init-error=false"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+          - name: device-plugin
+            mountPath: /var/lib/kubelet/device-plugins
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins

--- a/charts/nvidia-device-plugin/values.yaml
+++ b/charts/nvidia-device-plugin/values.yaml
@@ -1,0 +1,29 @@
+# NVIDIA Device Plugin DaemonSet Configuration
+
+image:
+  repository: nvcr.io/nvidia/k8s-device-plugin
+  tag: v0.16.2
+  pullPolicy: IfNotPresent
+
+# Node selector to only deploy on GPU nodes
+# Uses type=gpu to run on ALL GPU nodes (both jupyter and services)
+nodeSelector:
+  type: gpu
+
+# Toleration for GPU taints
+tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+
+# Resource limits for the plugin pods
+resources:
+  requests:
+    cpu: 50m
+    memory: 50Mi
+  limits:
+    cpu: 100m
+    memory: 100Mi
+
+# Priority class for system-critical workload
+priorityClassName: system-node-critical


### PR DESCRIPTION
### Scope of changes

Migrates infrastructure charts from `gcio-irs-tax-form-processor` to this dedicated helm charts repository for better separation of concerns.

**New charts added:**

1. **jupyterhub-rbac** (v0.1.0) - RBAC configuration for JupyterHub user pods
   - ServiceAccount, Role, and RoleBinding for user notebook pods
   - Grants permissions to get/list pods in namespace

2. **karpenter-nodepools** (v0.1.0) - Karpenter NodePool and EC2NodeClass definitions
   - CPU NodePool for standard workloads
   - GPU NodePool with NVIDIA tolerations for ML workloads
   - EC2NodeClass for both CPU and GPU instance types

3. **nvidia-device-plugin** (v0.1.0) - NVIDIA GPU device plugin for Kubernetes
   - DaemonSet for GPU node discovery
   - Tolerations for GPU-tainted nodes

### Type of change

- [ ] update app version
- [x] new objects/feature
- [ ] new/additional configuration
- [ ] documentation
- [ ] other (describe)

### Author checklist

- [x] I have manually debugged the charts using `helm debug`
- [ ] I have updated any affected `values.schema.json` files
- [x] I have updated the Chart Version for any affected charts