### PR TITLE
Add KMS key support to karpenter-nodepools EC2NodeClass

### DIFF
--- a/charts/karpenter-nodepools/Chart.yaml
+++ b/charts/karpenter-nodepools/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/karpenter-nodepools/templates/ec2nodeclass-default.yaml
+++ b/charts/karpenter-nodepools/templates/ec2nodeclass-default.yaml
@@ -45,6 +45,9 @@ spec:
         volumeType: gp3
         encrypted: true
         deleteOnTermination: true
+        {{- if .Values.ebsKmsKeyArn }}
+        kmsKeyID: {{ .Values.ebsKmsKeyArn }}
+        {{- end }}
 
   # IMDSv2 required for security
   metadataOptions:

--- a/charts/karpenter-nodepools/values.yaml
+++ b/charts/karpenter-nodepools/values.yaml
@@ -1,0 +1,11 @@
+# Karpenter NodePools and EC2NodeClass configuration
+
+# EKS cluster name - required for discovery tags
+clusterName: ""
+
+# IAM instance profile name for Karpenter-launched nodes
+nodeInstanceProfileName: ""
+
+# KMS key ARN for EBS volume encryption (optional)
+# If not provided, uses the account's default EBS encryption key
+ebsKmsKeyArn: ""


### PR DESCRIPTION
### Scope of changes

Adds optional KMS key configuration to the `karpenter-nodepools` chart for EBS volume encryption.

**Changes:**
- `values.yaml`: Added `ebsKmsKeyArn` parameter (optional, defaults to empty)
- `ec2nodeclass-default.yaml`: Conditionally includes `kmsKeyID` in blockDeviceMappings when `ebsKmsKeyArn` is provided

This is required for GovCloud environments where the default AWS-managed EBS encryption key may not be available or functional.

### Type of change

- [ ] update app version
- [x] new objects/feature
- [x] new/additional configuration
- [ ] documentation
- [ ] other (describe)

### Author checklist

- [x] I have manually debugged the charts using `helm debug`
- [ ] I have updated any affected `values.schema.json` files
- [x] I have updated the Chart Version for any affected charts