### PR TITLE
Fix migration job for distroless images

### DIFF
--- a/charts/lander/Chart.yaml
+++ b/charts/lander/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.8.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.8.1"
+appVersion: "0.8.2"
 
 # Project Information
 home: https://kungfu.ai

--- a/charts/lander/templates/jobs.yaml
+++ b/charts/lander/templates/jobs.yaml
@@ -28,9 +28,7 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: [ "/bin/sh", "-c" ]
-          args:
-            - "python -m alembic upgrade head"
+          command: ["python", "-m", "alembic", "upgrade", "head"]
           {{- include "lander.environment" . | nindent 10 }}
       restartPolicy: Never
   backoffLimit: {{ .Values.jobs.migrate.backoffLimit | default 5 }}


### PR DESCRIPTION
## Summary

- Remove `/bin/sh` dependency from lander migration job
- Distroless images don't include a shell, causing `StartError` in experimental

## Changes

- `charts/lander/templates/jobs.yaml`: Change command from `/bin/sh -c "python -m alembic..."` to direct `python -m alembic upgrade head`
- Bump chart version to 0.8.2

## Testing

Verified fix works in experimental:
```
kubectl run test-migrate --rm -it --restart=Never \
  --image=595425361112.dkr.ecr.us-east-2.amazonaws.com/facture-lander:0.10.0 \
  --namespace=facture \
  --command -- python -m alembic upgrade head
```

Fixes #15