### PR TITLE
fix(worker): correct EXTRACTOR_CONFIG path

### DIFF
--- a/charts/worker/Chart.yaml
+++ b/charts/worker/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.0
+version: 0.11.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.11.0"
+appVersion: "0.11.1"
 
 # Project Information
 home: https://kungfu.ai

--- a/charts/worker/values.yaml
+++ b/charts/worker/values.yaml
@@ -12,7 +12,7 @@ fullnameOverride: ""
 replicaCount: 1
 
 worker:
-  extractorConfig: /home/worker/app/config/extractor.json
+  extractorConfig: /app/config/extractor.json
 
 # AWS configuration
 aws:


### PR DESCRIPTION
## Summary
- Fix incorrect EXTRACTOR_CONFIG default path in worker chart
- Changed from `/home/worker/app/config/extractor.json` to `/app/config/extractor.json`
- The worker Dockerfile sets WORKDIR=/app and copies config there

## Root Cause
v0.12.1 deployment was failing with `OSError: EXTRACTOR_CONFIG environment variable is not set` - the env var was set, but the file path didn't exist in the container because the Dockerfile places it at `/app/config/extractor.json`.

## Test plan
- [ ] Merge and publish chart v0.11.1
- [ ] Redeploy worker to experimental
- [ ] Verify pod starts successfully