### PR TITLE
Add OTEL environment variables to worker, lander, and extractor charts

### DIFF
--- a/charts/extractor/Chart.yaml
+++ b/charts/extractor/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.0
+version: 0.12.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.11.0"
+appVersion: "0.12.0"
 
 # Project Information
 home: https://kungfu.ai

--- a/charts/extractor/templates/_environment.tpl
+++ b/charts/extractor/templates/_environment.tpl
@@ -17,4 +17,16 @@ env:
       secretKeyRef:
         name: {{ include "extractor.databaseURLSecretName" . }}
         key: {{ .Values.secrets.databaseURL.key }}
+
+  # OpenTelemetry
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Chart.Name | quote }}
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: {{ .Values.otel.endpoint | default "http://cloudwatch-agent.amazon-cloudwatch:4316" | quote }}
+  - name: OTEL_TRACES_EXPORTER
+    value: "otlp"
+  - name: OTEL_METRICS_EXPORTER
+    value: "none"
+  - name: OTEL_LOGS_EXPORTER
+    value: "none"
 {{- end -}}

--- a/charts/extractor/values.yaml
+++ b/charts/extractor/values.yaml
@@ -19,6 +19,10 @@ updateStrategy:
 
 extractor: {}
 
+# OpenTelemetry
+otel:
+  endpoint: "http://cloudwatch-agent.amazon-cloudwatch:4316"
+
 # AWS configuration
 aws:
   region: us-east-2

--- a/charts/lander/Chart.yaml
+++ b/charts/lander/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.0
+version: 0.12.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.11.0"
+appVersion: "0.12.0"
 
 # Project Information
 home: https://kungfu.ai

--- a/charts/lander/templates/_environment.tpl
+++ b/charts/lander/templates/_environment.tpl
@@ -32,4 +32,16 @@ env:
       secretKeyRef:
         name: {{ include "lander.databaseURLSecretName" . }}
         key: {{ .Values.secrets.databaseURL.key }}
+
+  # OpenTelemetry
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Chart.Name | quote }}
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: {{ .Values.otel.endpoint | default "http://cloudwatch-agent.amazon-cloudwatch:4316" | quote }}
+  - name: OTEL_TRACES_EXPORTER
+    value: "otlp"
+  - name: OTEL_METRICS_EXPORTER
+    value: "none"
+  - name: OTEL_LOGS_EXPORTER
+    value: "none"
 {{- end -}}

--- a/charts/lander/values.yaml
+++ b/charts/lander/values.yaml
@@ -13,6 +13,10 @@ replicaCount: 1
 
 lander: {}
 
+# OpenTelemetry
+otel:
+  endpoint: "http://cloudwatch-agent.amazon-cloudwatch:4316"
+
 # AWS configuration
 aws:
   region: us-east-2

--- a/charts/worker/Chart.yaml
+++ b/charts/worker/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.1
+version: 0.12.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.11.1"
+appVersion: "0.12.0"
 
 # Project Information
 home: https://kungfu.ai

--- a/charts/worker/templates/_environment.tpl
+++ b/charts/worker/templates/_environment.tpl
@@ -30,4 +30,16 @@ env:
       secretKeyRef:
         name: {{ include "worker.databaseURLSecretName" . }}
         key: {{ .Values.secrets.databaseURL.key }}
+
+  # OpenTelemetry
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Chart.Name | quote }}
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: {{ .Values.otel.endpoint | default "http://cloudwatch-agent.amazon-cloudwatch:4316" | quote }}
+  - name: OTEL_TRACES_EXPORTER
+    value: "otlp"
+  - name: OTEL_METRICS_EXPORTER
+    value: "none"
+  - name: OTEL_LOGS_EXPORTER
+    value: "none"
 {{- end -}}

--- a/charts/worker/values.yaml
+++ b/charts/worker/values.yaml
@@ -14,6 +14,10 @@ replicaCount: 1
 worker:
   extractorConfig: /app/config/extractor.json
 
+# OpenTelemetry
+otel:
+  endpoint: "http://cloudwatch-agent.amazon-cloudwatch:4316"
+
 # AWS configuration
 aws:
   region: us-east-2


### PR DESCRIPTION
### Scope of changes

Add OpenTelemetry configuration environment variables to all three service charts (worker, lander, extractor) to support OTEL auto-instrumentation added in kungfuai/gcio-irs-tax-form-processor#243.

Changes per chart:
- `_environment.tpl` — 5 new env vars: `OTEL_SERVICE_NAME`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_TRACES_EXPORTER`, `OTEL_METRICS_EXPORTER`, `OTEL_LOGS_EXPORTER`
- `values.yaml` — `otel.endpoint` default (`http://cloudwatch-agent.amazon-cloudwatch:4316`)
- `Chart.yaml` — bumped to 0.12.0

### Type of change

- [x] new/additional configuration

### Author checklist

- [ ] I have manually debugged the charts using `helm debug`
- [ ] I have updated any affected `values.schema.json` files
- [x] I have updated the Chart Version for any affected charts