### PR TITLE
version 15 bump and remove source bucket

### DIFF
--- a/charts/extractor/Chart.yaml
+++ b/charts/extractor/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.1
+version: 0.15.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.14.0"
+appVersion: "0.15.0"
 
 # Project Information
 home: https://kungfu.ai

--- a/charts/lander/Chart.yaml
+++ b/charts/lander/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.1
+version: 0.15.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.14.0"
+appVersion: "0.15.0"
 
 # Project Information
 home: https://kungfu.ai

--- a/charts/lander/templates/_environment.tpl
+++ b/charts/lander/templates/_environment.tpl
@@ -9,8 +9,6 @@ env:
     value: {{ .Values.aws.region | quote }}
   - name: S3_BUCKET
     value: {{ required "aws.s3.cacheBucket is required" .Values.aws.s3.cacheBucket | quote }}
-  - name: S3_SOURCE_BUCKET
-    value: {{ required "aws.s3.sourceBucket is required" .Values.aws.s3.sourceBucket | quote }}
   - name: SQS_WORKER_QUEUE_URL
     value: {{ required "aws.sqs.workerQueueURL is required" .Values.aws.sqs.workerQueueURL | quote }}
   - name: SQS_STATUS_QUEUE_URL

--- a/charts/lander/values.yaml
+++ b/charts/lander/values.yaml
@@ -24,7 +24,6 @@ aws:
   region: us-east-2
   s3:
     cacheBucket: ""   # Required - must be set per environment
-    sourceBucket: ""  # Required - must be set per environment
   sqs:
     workerQueueURL: ""
     statusQueueURL: ""

--- a/charts/worker/Chart.yaml
+++ b/charts/worker/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.1
+version: 0.15.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.14.0"
+appVersion: "0.15.0"
 
 # Project Information
 home: https://kungfu.ai


### PR DESCRIPTION
### Scope of changes

Updates to v0.15.0 and removes the source bucket from the lander config. 

### Type of change

- [x] update app version
- [ ] new objects/feature
- [ ] new/additional configuration
- [ ] documentation
- [x] other (describe)

### Author checklist

- [x] I have manually debugged the charts using `helm debug`
- [ ] I have updated any affected `values.schema.json` files
- [ ] I have updated the Chart Version for any affected charts
