### PR TITLE
Add date pipeline model artifact chart values

### DIFF
--- a/charts/extractor/Chart.yaml
+++ b/charts/extractor/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.0
+version: 0.20.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/extractor/ci/all-values.yaml
+++ b/charts/extractor/ci/all-values.yaml
@@ -11,3 +11,9 @@ extractor:
     vlmDateExtractor: us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0
     parserModel: us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0
     checkModel: us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0
+
+datePipelineArtifacts:
+  rfdetrStampDateDetectorCheckpoint: s3://kfai-testing-cache/models/vlm_stamp_date_detector/base/checkpoint_best_total.pth
+  vlmStampDateReaderCheckpoint: s3://kfai-testing-cache/models/vlm_stamp_date_reader/v4/mistralai/Ministral-3-3B-Instruct-2512-BF16/checkpoint-2500
+  vlmStampDateBaseModel: s3://kfai-testing-cache/models/ministral-3-3b-instruct-2512-bf16/
+  gem4encStampDateReaderCheckpoint: s3://kfai-testing-cache/models/gem4enc_stamp_date_reader/stage2-full-280/checkpoint-5000/

--- a/charts/extractor/templates/_environment.tpl
+++ b/charts/extractor/templates/_environment.tpl
@@ -49,6 +49,22 @@ env:
   - name: CHECK_MODEL
     value: {{ .Values.extractor.models.checkModel | quote }}
   {{- end }}
+  {{- if .Values.datePipelineArtifacts.rfdetrStampDateDetectorCheckpoint }}
+  - name: RFDETR_STAMP_DATE_DETECTOR_CHECKPOINT
+    value: {{ .Values.datePipelineArtifacts.rfdetrStampDateDetectorCheckpoint | quote }}
+  {{- end }}
+  {{- if .Values.datePipelineArtifacts.vlmStampDateReaderCheckpoint }}
+  - name: VLM_STAMP_DATE_READER_CHECKPOINT
+    value: {{ .Values.datePipelineArtifacts.vlmStampDateReaderCheckpoint | quote }}
+  {{- end }}
+  {{- if .Values.datePipelineArtifacts.vlmStampDateBaseModel }}
+  - name: VLM_STAMP_DATE_BASE_MODEL
+    value: {{ .Values.datePipelineArtifacts.vlmStampDateBaseModel | quote }}
+  {{- end }}
+  {{- if .Values.datePipelineArtifacts.gem4encStampDateReaderCheckpoint }}
+  - name: GEM4ENC_STAMP_DATE_READER_CHECKPOINT
+    value: {{ .Values.datePipelineArtifacts.gem4encStampDateReaderCheckpoint | quote }}
+  {{- end }}
   # OpenTelemetry — configured via Instrumentation CRD (auto-instrumentation)
   # The ADOT operator injects OTEL env vars automatically when the pod annotation
   # instrumentation.opentelemetry.io/inject-python: "true" is present.

--- a/charts/extractor/values.yaml
+++ b/charts/extractor/values.yaml
@@ -30,6 +30,12 @@ extractor:
     parserModel: null
     checkModel: null
 
+datePipelineArtifacts:
+  rfdetrStampDateDetectorCheckpoint: null
+  vlmStampDateReaderCheckpoint: null
+  vlmStampDateBaseModel: null
+  gem4encStampDateReaderCheckpoint: null
+
 # AWS configuration
 aws:
   region: us-east-2

--- a/charts/worker/Chart.yaml
+++ b/charts/worker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.0
+version: 0.20.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/worker/Chart.yaml
+++ b/charts/worker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.1
+version: 0.20.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/worker/ci/all-values.yaml
+++ b/charts/worker/ci/all-values.yaml
@@ -3,3 +3,9 @@ aws:
   sqs:
     workerQueueURL: "kfai-testing-worker-queue-url"
     statusQueueURL: "kfai-testing-status-queue-url"
+
+datePipelineArtifacts:
+  rfdetrStampDateDetectorCheckpoint: s3://kfai-testing-cache/models/vlm_stamp_date_detector/base/checkpoint_best_total.pth
+  vlmStampDateReaderCheckpoint: s3://kfai-testing-cache/models/vlm_stamp_date_reader/v4/mistralai/Ministral-3-3B-Instruct-2512-BF16/checkpoint-2500
+  vlmStampDateBaseModel: s3://kfai-testing-cache/models/ministral-3-3b-instruct-2512-bf16/
+  gem4encStampDateReaderCheckpoint: s3://kfai-testing-cache/models/gem4enc_stamp_date_reader/stage2-full-280/checkpoint-5000/

--- a/charts/worker/ci/all-values.yaml
+++ b/charts/worker/ci/all-values.yaml
@@ -3,9 +3,3 @@ aws:
   sqs:
     workerQueueURL: "kfai-testing-worker-queue-url"
     statusQueueURL: "kfai-testing-status-queue-url"
-
-datePipelineArtifacts:
-  rfdetrStampDateDetectorCheckpoint: s3://kfai-testing-cache/models/vlm_stamp_date_detector/base/checkpoint_best_total.pth
-  vlmStampDateReaderCheckpoint: s3://kfai-testing-cache/models/vlm_stamp_date_reader/v4/mistralai/Ministral-3-3B-Instruct-2512-BF16/checkpoint-2500
-  vlmStampDateBaseModel: s3://kfai-testing-cache/models/ministral-3-3b-instruct-2512-bf16/
-  gem4encStampDateReaderCheckpoint: s3://kfai-testing-cache/models/gem4enc_stamp_date_reader/stage2-full-280/checkpoint-5000/

--- a/charts/worker/templates/_environment.tpl
+++ b/charts/worker/templates/_environment.tpl
@@ -49,24 +49,6 @@ env:
         name: {{ include "worker.databaseURLSecretName" . }}
         key: {{ .Values.secrets.databaseURL.key }}
 
-  # Date pipeline model artifacts
-  {{- if .Values.datePipelineArtifacts.rfdetrStampDateDetectorCheckpoint }}
-  - name: RFDETR_STAMP_DATE_DETECTOR_CHECKPOINT
-    value: {{ .Values.datePipelineArtifacts.rfdetrStampDateDetectorCheckpoint | quote }}
-  {{- end }}
-  {{- if .Values.datePipelineArtifacts.vlmStampDateReaderCheckpoint }}
-  - name: VLM_STAMP_DATE_READER_CHECKPOINT
-    value: {{ .Values.datePipelineArtifacts.vlmStampDateReaderCheckpoint | quote }}
-  {{- end }}
-  {{- if .Values.datePipelineArtifacts.vlmStampDateBaseModel }}
-  - name: VLM_STAMP_DATE_BASE_MODEL
-    value: {{ .Values.datePipelineArtifacts.vlmStampDateBaseModel | quote }}
-  {{- end }}
-  {{- if .Values.datePipelineArtifacts.gem4encStampDateReaderCheckpoint }}
-  - name: GEM4ENC_STAMP_DATE_READER_CHECKPOINT
-    value: {{ .Values.datePipelineArtifacts.gem4encStampDateReaderCheckpoint | quote }}
-  {{- end }}
-
   # OpenTelemetry — configured via Instrumentation CRD (auto-instrumentation)
   # The ADOT operator injects OTEL env vars automatically when the pod annotation
   # instrumentation.opentelemetry.io/inject-python: "true" is present.

--- a/charts/worker/templates/_environment.tpl
+++ b/charts/worker/templates/_environment.tpl
@@ -49,6 +49,24 @@ env:
         name: {{ include "worker.databaseURLSecretName" . }}
         key: {{ .Values.secrets.databaseURL.key }}
 
+  # Date pipeline model artifacts
+  {{- if .Values.datePipelineArtifacts.rfdetrStampDateDetectorCheckpoint }}
+  - name: RFDETR_STAMP_DATE_DETECTOR_CHECKPOINT
+    value: {{ .Values.datePipelineArtifacts.rfdetrStampDateDetectorCheckpoint | quote }}
+  {{- end }}
+  {{- if .Values.datePipelineArtifacts.vlmStampDateReaderCheckpoint }}
+  - name: VLM_STAMP_DATE_READER_CHECKPOINT
+    value: {{ .Values.datePipelineArtifacts.vlmStampDateReaderCheckpoint | quote }}
+  {{- end }}
+  {{- if .Values.datePipelineArtifacts.vlmStampDateBaseModel }}
+  - name: VLM_STAMP_DATE_BASE_MODEL
+    value: {{ .Values.datePipelineArtifacts.vlmStampDateBaseModel | quote }}
+  {{- end }}
+  {{- if .Values.datePipelineArtifacts.gem4encStampDateReaderCheckpoint }}
+  - name: GEM4ENC_STAMP_DATE_READER_CHECKPOINT
+    value: {{ .Values.datePipelineArtifacts.gem4encStampDateReaderCheckpoint | quote }}
+  {{- end }}
+
   # OpenTelemetry — configured via Instrumentation CRD (auto-instrumentation)
   # The ADOT operator injects OTEL env vars automatically when the pod annotation
   # instrumentation.opentelemetry.io/inject-python: "true" is present.

--- a/charts/worker/values.yaml
+++ b/charts/worker/values.yaml
@@ -22,6 +22,12 @@ worker:
     waitSeconds: 30
     numWorkers: 1
 
+datePipelineArtifacts:
+  rfdetrStampDateDetectorCheckpoint: null
+  vlmStampDateReaderCheckpoint: null
+  vlmStampDateBaseModel: null
+  gem4encStampDateReaderCheckpoint: null
+
 # AWS configuration
 aws:
   region: us-east-2

--- a/charts/worker/values.yaml
+++ b/charts/worker/values.yaml
@@ -22,12 +22,6 @@ worker:
     waitSeconds: 30
     numWorkers: 1
 
-datePipelineArtifacts:
-  rfdetrStampDateDetectorCheckpoint: null
-  vlmStampDateReaderCheckpoint: null
-  vlmStampDateBaseModel: null
-  gem4encStampDateReaderCheckpoint: null
-
 # AWS configuration
 aws:
   region: us-east-2


### PR DESCRIPTION
### Scope of changes

Updates the extractor and worker charts to expose date-pipeline model artifact paths as environment-owned values:

- `RFDETR_STAMP_DATE_DETECTOR_CHECKPOINT`
- `VLM_STAMP_DATE_READER_CHECKPOINT`
- `VLM_STAMP_DATE_BASE_MODEL`
- `GEM4ENC_STAMP_DATE_READER_CHECKPOINT`

Also adds CI render values for both charts and bumps extractor/worker chart versions from `0.20.0` to `0.20.1`.

### Type of change

- [x] update app version
- [ ] new objects/feature
- [x] new/additional configuration
- [ ] documentation
- [ ] other (describe)

### Author checklist

- [x] I have manually debugged the charts using `helm debug`
- [x] I have updated any affected `values.schema.json` files
- [x] I have updated the Chart Version for any affected charts

Validation:

- `helm lint charts/extractor --values charts/extractor/ci/all-values.yaml`
- `helm lint charts/worker --values charts/worker/ci/all-values.yaml`
- `helm template extractor charts/extractor --values charts/extractor/ci/all-values.yaml --debug`
- `helm template worker charts/worker --values charts/worker/ci/all-values.yaml --debug`

No `values.schema.json` files exist for these charts.
