### PR TITLE
Add worker notifier chart wiring

### DIFF
--- a/charts/worker/Chart.yaml
+++ b/charts/worker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.0
+version: 0.20.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/worker/ci/all-values.yaml
+++ b/charts/worker/ci/all-values.yaml
@@ -6,7 +6,7 @@ aws:
 worker:
   notifier:
     enabled: true
-    transcriptionURL: "https://example.test/facture/transcriptions"
+    transcriptionURL: "https://example.test/integrations/kungfu-ai/tasks/transcription"
 secrets:
   notifierApiKey:
     name: "kfai-testing-notifier"

--- a/charts/worker/ci/all-values.yaml
+++ b/charts/worker/ci/all-values.yaml
@@ -3,3 +3,10 @@ aws:
   sqs:
     workerQueueURL: "kfai-testing-worker-queue-url"
     statusQueueURL: "kfai-testing-status-queue-url"
+worker:
+  notifier:
+    enabled: true
+    transcriptionURL: "https://example.test/facture/transcriptions"
+secrets:
+  notifierApiKey:
+    name: "kfai-testing-notifier"

--- a/charts/worker/templates/_environment.tpl
+++ b/charts/worker/templates/_environment.tpl
@@ -3,6 +3,14 @@ Facture pods are configured primarily through the environment. Environment varia
 are set and defined here using configuration values from the values.yaml file.
 */}}
 {{- define "worker.environment" -}}
+{{- $notifier := .Values.worker.notifier -}}
+{{- $notifierURLCount := list $notifier.transcriptionURL $notifier.acknowledgementURL $notifier.issueURL | compact | len -}}
+{{- if and $notifier.enabled (eq $notifierURLCount 0) -}}
+{{- fail "worker.notifier.enabled requires at least one notifier URL" -}}
+{{- end -}}
+{{- if and $notifier.enabled (not .Values.secrets.notifierApiKey.name) -}}
+{{- fail "worker.notifier.enabled requires secrets.notifierApiKey.name" -}}
+{{- end -}}
 env:
   # AWS Configuration
   - name: AWS_DEFAULT_REGION
@@ -41,6 +49,35 @@ env:
     value: {{ .Values.worker.sqs.waitSeconds | default 30 | quote }}
   - name: SQS_NUM_WORKERS
     value: {{ .Values.worker.sqs.numWorkers | default 1 | quote }}
+
+  # GovCIO completion/status notifier
+  - name: NOTIFIER_ENABLED
+    value: {{ $notifier.enabled | quote }}
+  - name: NOTIFIER_DRAIN_QUEUE
+    value: {{ $notifier.drainQueue | quote }}
+  - name: NOTIFIER_TIMEOUT
+    value: {{ $notifier.timeout | default 30 | quote }}
+  - name: NOTIFIER_RETRIES
+    value: {{ $notifier.retries | default 3 | quote }}
+  {{- if $notifier.transcriptionURL }}
+  - name: NOTIFIER_TRANSCRIPTION_URL
+    value: {{ $notifier.transcriptionURL | quote }}
+  {{- end }}
+  {{- if $notifier.acknowledgementURL }}
+  - name: NOTIFIER_ACKNOWLEDGEMENT_URL
+    value: {{ $notifier.acknowledgementURL | quote }}
+  {{- end }}
+  {{- if $notifier.issueURL }}
+  - name: NOTIFIER_ISSUE_URL
+    value: {{ $notifier.issueURL | quote }}
+  {{- end }}
+  {{- if .Values.secrets.notifierApiKey.name }}
+  - name: NOTIFIER_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.secrets.notifierApiKey.name | quote }}
+        key: {{ .Values.secrets.notifierApiKey.key | quote }}
+  {{- end }}
 
   # Database (from secret)
   - name: DATABASE_URL

--- a/charts/worker/values.yaml
+++ b/charts/worker/values.yaml
@@ -15,6 +15,14 @@ worker:
   extractorConfig: /app/config/pipeline.yaml
   extractorCertPath: ""  # Optional - TLS cert for extractor service
   logLevel: "INFO"
+  notifier:
+    enabled: false
+    drainQueue: false
+    transcriptionURL: ""
+    acknowledgementURL: ""
+    issueURL: ""
+    timeout: 30
+    retries: 3
   sqs:
     maxRetries: 3
     maxMessages: 1
@@ -48,6 +56,9 @@ secrets:
     name: ""
     key: "database-url"
     value: ""
+  notifierApiKey:
+    name: ""
+    key: "notifier-api-key"
 
 image:
   repository: 595425361112.dkr.ecr.us-east-2.amazonaws.com/facture-worker


### PR DESCRIPTION
### Scope of changes

Adds optional worker notifier configuration for the GCIO completion/status callback path. The worker chart now renders NOTIFIER_ENABLED, NOTIFIER_DRAIN_QUEUE, NOTIFIER_TIMEOUT, and NOTIFIER_RETRIES with safe defaults, optionally renders notifier endpoint URLs, and injects NOTIFIER_API_KEY from an existing Kubernetes Secret when configured.

Notifier remains disabled by default so existing deployments do not require GCIO endpoint URLs or keys yet. When enabled, chart rendering fails fast unless at least one notifier URL and the API-key secret name are provided.

### Type of change

- [ ] update app version
- [x] new objects/feature
- [x] new/additional configuration
- [ ] documentation
- [ ] other (describe)

### Author checklist

- [x] I have manually debugged the charts using `helm debug`
- [x] I have updated any affected `values.schema.json` files
- [x] I have updated the Chart Version for any affected charts

Validation:
- `helm lint charts/worker --values charts/worker/ci/all-values.yaml`
- `helm template worker charts/worker --values charts/worker/ci/all-values.yaml | rg -n "NOTIFIER_|notifier-api-key|kfai-testing-notifier"`
- `helm template worker charts/worker --set aws.s3Bucket=x --set aws.sqs.workerQueueURL=x --set aws.sqs.statusQueueURL=x | rg -n "NOTIFIER_|notifier-api-key"`
- confirmed enabled notifier fails fast without URLs
- confirmed enabled notifier fails fast without API-key secret name