### PR TITLE
Wire worker notifier client secret env

### DIFF
--- a/charts/worker/Chart.yaml
+++ b/charts/worker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.1
+version: 0.20.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/worker/ci/all-values.yaml
+++ b/charts/worker/ci/all-values.yaml
@@ -6,7 +6,8 @@ aws:
 worker:
   notifier:
     enabled: true
-    transcriptionURL: "https://example.test/integrations/kungfu-ai/tasks/transcription"
+    clientID: "kfai-testing-client-id"
+    transcriptionURL: "https://example.test/integrations/kungfu-ai/task/transcription"
 secrets:
-  notifierApiKey:
+  notifierClientSecret:
     name: "kfai-testing-notifier"

--- a/charts/worker/templates/_environment.tpl
+++ b/charts/worker/templates/_environment.tpl
@@ -8,8 +8,11 @@ are set and defined here using configuration values from the values.yaml file.
 {{- if and $notifier.enabled (eq $notifierURLCount 0) -}}
 {{- fail "worker.notifier.enabled requires at least one notifier URL" -}}
 {{- end -}}
-{{- if and $notifier.enabled (not .Values.secrets.notifierApiKey.name) -}}
-{{- fail "worker.notifier.enabled requires secrets.notifierApiKey.name" -}}
+{{- if and $notifier.enabled (not $notifier.clientID) -}}
+{{- fail "worker.notifier.enabled requires worker.notifier.clientID" -}}
+{{- end -}}
+{{- if and $notifier.enabled (not .Values.secrets.notifierClientSecret.name) -}}
+{{- fail "worker.notifier.enabled requires secrets.notifierClientSecret.name" -}}
 {{- end -}}
 env:
   # AWS Configuration
@@ -59,6 +62,10 @@ env:
     value: {{ $notifier.timeout | default 30 | quote }}
   - name: NOTIFIER_RETRIES
     value: {{ $notifier.retries | default 3 | quote }}
+  {{- if $notifier.clientID }}
+  - name: NOTIFIER_CLIENT_ID
+    value: {{ $notifier.clientID | quote }}
+  {{- end }}
   {{- if $notifier.transcriptionURL }}
   - name: NOTIFIER_TRANSCRIPTION_URL
     value: {{ $notifier.transcriptionURL | quote }}
@@ -71,12 +78,12 @@ env:
   - name: NOTIFIER_ISSUE_URL
     value: {{ $notifier.issueURL | quote }}
   {{- end }}
-  {{- if .Values.secrets.notifierApiKey.name }}
-  - name: NOTIFIER_API_KEY
+  {{- if .Values.secrets.notifierClientSecret.name }}
+  - name: NOTIFIER_CLIENT_SECRET
     valueFrom:
       secretKeyRef:
-        name: {{ .Values.secrets.notifierApiKey.name | quote }}
-        key: {{ .Values.secrets.notifierApiKey.key | quote }}
+        name: {{ .Values.secrets.notifierClientSecret.name | quote }}
+        key: {{ .Values.secrets.notifierClientSecret.key | quote }}
   {{- end }}
 
   # Database (from secret)

--- a/charts/worker/values.yaml
+++ b/charts/worker/values.yaml
@@ -18,6 +18,7 @@ worker:
   notifier:
     enabled: false
     drainQueue: false
+    clientID: ""
     transcriptionURL: ""
     acknowledgementURL: ""
     issueURL: ""
@@ -56,9 +57,10 @@ secrets:
     name: ""
     key: "database-url"
     value: ""
-  notifierApiKey:
+  notifierClientSecret:
     name: ""
-    key: "notifier-api-key"
+    # Backing Kubernetes Secret data key created by operations.
+    key: "NOTIFIER_CLIENT_SECRET"
 
 image:
   repository: 595425361112.dkr.ecr.us-east-2.amazonaws.com/facture-worker


### PR DESCRIPTION
### Scope of changes

Updates the worker chart notifier env wiring to match the application runtime contract from `gcio-irs-tax-form-processor` PR #567.

- adds `worker.notifier.clientID`
- replaces old `secrets.notifierApiKey` / `NOTIFIER_API_KEY` wiring with `secrets.notifierClientSecret` / `NOTIFIER_CLIENT_SECRET`
- renders `NOTIFIER_CLIENT_ID` when configured
- validates notifier-enabled deployments include a URL, client ID, and client secret reference
- bumps worker chart version to `0.20.2`

### Type of change

- [ ] update app version
- [ ] new objects/feature
- [x] new/additional configuration
- [ ] documentation
- [ ] other (describe)

### Author checklist

- [x] I have manually debugged the charts using `helm debug`
- [ ] I have updated any affected `values.schema.json` files
- [x] I have updated the Chart Version for any affected charts

No `values.schema.json` exists for the worker chart.

### Validation

- `helm lint charts/worker -f charts/worker/ci/all-values.yaml`
- `helm template worker-test charts/worker -f charts/worker/ci/all-values.yaml`
- rendered output emits `NOTIFIER_CLIENT_ID` and `NOTIFIER_CLIENT_SECRET`, not `NOTIFIER_API_KEY`
