### PR TITLE
Bump worker notifier chart version

### DIFF
--- a/charts/worker/Chart.yaml
+++ b/charts/worker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.2
+version: 0.20.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
### Scope of changes

Bumps the worker chart version to `0.20.3` so the notifier client-secret chart changes publish under a new immutable chart package.

PR #38 updated the chart content but reused `0.20.2`, which already existed in the chart repository. Sandbox therefore deployed the old published `worker-0.20.2` package and did not render the notifier env vars.

### Type of change

- [ ] update app version
- [ ] new objects/feature
- [ ] new/additional configuration
- [ ] documentation
- [x] other (describe): chart version bump for already-merged notifier wiring

### Author checklist

- [x] I have manually debugged the charts using `helm debug`
- [ ] I have updated any affected `values.schema.json` files
- [x] I have updated the Chart Version for any affected charts

No `values.schema.json` exists for the worker chart.

### Validation

- `helm lint charts/worker -f charts/worker/ci/all-values.yaml`
- `helm template worker-test charts/worker -f charts/worker/ci/all-values.yaml`
- rendered output labels chart as `worker-0.20.3` and emits `NOTIFIER_CLIENT_ID` / `NOTIFIER_CLIENT_SECRET`
