### PR TITLE
Wire worker notifier chart env

### DIFF
--- a/charts/worker/Chart.yaml
+++ b/charts/worker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.2
+version: 0.20.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/worker/ci/all-values.yaml
+++ b/charts/worker/ci/all-values.yaml
@@ -3,3 +3,11 @@ aws:
   sqs:
     workerQueueURL: "kfai-testing-worker-queue-url"
     statusQueueURL: "kfai-testing-status-queue-url"
+worker:
+  notifier:
+    enabled: true
+    clientID: "kfai-testing-client-id"
+    transcriptionURL: "https://example.test/integrations/kungfu-ai/task/transcription"
+secrets:
+  notifierClientSecret:
+    name: "kfai-testing-notifier"

--- a/charts/worker/templates/_environment.tpl
+++ b/charts/worker/templates/_environment.tpl
@@ -3,6 +3,17 @@ Facture pods are configured primarily through the environment. Environment varia
 are set and defined here using configuration values from the values.yaml file.
 */}}
 {{- define "worker.environment" -}}
+{{- $notifier := .Values.worker.notifier -}}
+{{- $notifierURLCount := list $notifier.transcriptionURL $notifier.acknowledgementURL $notifier.issueURL | compact | len -}}
+{{- if and $notifier.enabled (eq $notifierURLCount 0) -}}
+{{- fail "worker.notifier.enabled requires at least one notifier URL" -}}
+{{- end -}}
+{{- if and $notifier.enabled (not $notifier.clientID) -}}
+{{- fail "worker.notifier.enabled requires worker.notifier.clientID" -}}
+{{- end -}}
+{{- if and $notifier.enabled (not .Values.secrets.notifierClientSecret.name) -}}
+{{- fail "worker.notifier.enabled requires secrets.notifierClientSecret.name" -}}
+{{- end -}}
 env:
   # AWS Configuration
   - name: AWS_DEFAULT_REGION
@@ -45,6 +56,39 @@ env:
     value: {{ .Values.worker.sqs.waitSeconds | default 30 | quote }}
   - name: SQS_NUM_WORKERS
     value: {{ .Values.worker.sqs.numWorkers | default 1 | quote }}
+
+  # GovCIO completion/status notifier
+  - name: NOTIFIER_ENABLED
+    value: {{ $notifier.enabled | quote }}
+  - name: NOTIFIER_DRAIN_QUEUE
+    value: {{ $notifier.drainQueue | quote }}
+  - name: NOTIFIER_TIMEOUT
+    value: {{ $notifier.timeout | default 30 | quote }}
+  - name: NOTIFIER_RETRIES
+    value: {{ $notifier.retries | default 3 | quote }}
+  {{- if $notifier.clientID }}
+  - name: NOTIFIER_CLIENT_ID
+    value: {{ $notifier.clientID | quote }}
+  {{- end }}
+  {{- if $notifier.transcriptionURL }}
+  - name: NOTIFIER_TRANSCRIPTION_URL
+    value: {{ $notifier.transcriptionURL | quote }}
+  {{- end }}
+  {{- if $notifier.acknowledgementURL }}
+  - name: NOTIFIER_ACKNOWLEDGEMENT_URL
+    value: {{ $notifier.acknowledgementURL | quote }}
+  {{- end }}
+  {{- if $notifier.issueURL }}
+  - name: NOTIFIER_ISSUE_URL
+    value: {{ $notifier.issueURL | quote }}
+  {{- end }}
+  {{- if .Values.secrets.notifierClientSecret.name }}
+  - name: NOTIFIER_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.secrets.notifierClientSecret.name | quote }}
+        key: {{ .Values.secrets.notifierClientSecret.key | quote }}
+  {{- end }}
 
   # Database (from secret)
   - name: DATABASE_URL

--- a/charts/worker/values.yaml
+++ b/charts/worker/values.yaml
@@ -15,6 +15,15 @@ worker:
   extractorConfig: /app/config/pipeline.yaml
   extractorCertPath: ""  # Optional - TLS cert for extractor service
   logLevel: "INFO"
+  notifier:
+    enabled: false
+    drainQueue: false
+    clientID: ""
+    transcriptionURL: ""
+    acknowledgementURL: ""
+    issueURL: ""
+    timeout: 30
+    retries: 3
   sqs:
     maxRetries: 3
     maxMessages: 1
@@ -49,6 +58,10 @@ secrets:
     name: ""
     key: "database-url"
     value: ""
+  notifierClientSecret:
+    name: ""
+    # Backing Kubernetes Secret data key created by operations.
+    key: "NOTIFIER_CLIENT_SECRET"
 
 image:
   repository: 595425361112.dkr.ecr.us-east-2.amazonaws.com/facture-worker


### PR DESCRIPTION
### Scope of changes

Wires the worker chart for the GovCIO notifier runtime contract:

- adds worker notifier values for enabled/drain/client ID/URLs/timeout/retries
- renders `NOTIFIER_CLIENT_ID` and `NOTIFIER_CLIENT_SECRET` into the worker pod env
- validates enabled notifier config has at least one URL, a client ID, and a secret ref
- bumps the worker chart from `0.20.2` to `0.20.3` so the release workflow publishes a new chart package

This is targeted at `main` because chart releases are published from `main`, not `dev`.

### Type of change

- [ ] update app version
- [ ] new objects/feature
- [x] new/additional configuration
- [ ] documentation
- [ ] other (describe)

### Author checklist

- [x] I have manually debugged the charts using `helm debug`
- [x] I have updated any affected `values.schema.json` files
- [x] I have updated the Chart Version for any affected charts

Validation:

- `helm lint charts/worker -f charts/worker/ci/all-values.yaml`
- `helm template worker-test charts/worker -f charts/worker/ci/all-values.yaml | rg 'helm.sh/chart|NOTIFIER_|kfai-testing-client-id|kfai-testing-notifier'`

No `values.schema.json` files exist in this repo.
