### PR TITLE
Add Ospere Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ facture` to see the charts.
 - [Lander](charts/lander/README.md) - HTTP API for document ingestion
 - [Worker](charts/worker/README.md) - Document processing pipeline orchestrator
 - [Extractor](charts/extractor/README.md) - GPU/LLM inference service
+- [Ospere](charts/ospere/README.md) - Django service for IRS MeF filing orchestration
 
 ### Infrastructure Charts
 - `jupyterhub-rbac` - RBAC configuration for JupyterHub notebook pods

--- a/charts/ospere/.helmignore
+++ b/charts/ospere/.helmignore
@@ -1,0 +1,8 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.github/
+.helmignore
+*.swp
+*.tmp

--- a/charts/ospere/Chart.yaml
+++ b/charts/ospere/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: ospere
+description: Django service for IRS MeF filing orchestration, schema validation, and filing lifecycle state.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+home: https://kungfu.ai
+icon: https://cdn.prod.website-files.com/626ff088dc91e832fe2f3249/680e74ec5378b7b440b03b0c_32x32.png
+sources:
+  - https://github.com/kungfuai/gcio-irs-mef-service
+maintainers:
+  - name: KungFu.ai
+    email: daas-support@kungfu.ai

--- a/charts/ospere/README.md
+++ b/charts/ospere/README.md
@@ -13,6 +13,12 @@ The chart follows the same service pattern as the existing Facture charts:
 
 Celery workloads are disabled by default until the filing lifecycle moves to asynchronous jobs.
 
+MeF A2A configuration requires more than the mounted certificate. The chart exposes
+the X.509 cert path, private key path, `AppSysID` (`MEF_CLIENT_SYSTEM_ID`), EFIN,
+ETIN, software ID, endpoint, environment, and WSDL paths. The application must also
+read any exposed env vars; at chart introduction time Ospere still needs app-side
+support for `MEF_SOFTWARE_ID`.
+
 Environment wiring should provide the public host through chart values. The expected
 GovCIO host pattern is:
 

--- a/charts/ospere/README.md
+++ b/charts/ospere/README.md
@@ -1,0 +1,26 @@
+# Ospere Helm Chart
+
+Deploys the Ospere Django service for IRS MeF filing orchestration.
+
+The chart follows the same service pattern as the existing Facture charts:
+
+- Django/Gunicorn web deployment
+- optional Django migration hook job
+- service account with IRSA annotations
+- database and application secrets by reference
+- optional ingress
+- optional Celery worker and beat deployments that use the same image
+
+Celery workloads are disabled by default until the filing lifecycle moves to asynchronous jobs.
+
+Environment wiring should provide the public host through chart values. The expected
+GovCIO host pattern is:
+
+- sandbox/dev: `ospere.<dev-domain>`
+- test: `ospere.<test-domain>`
+- production: `ospere.<prod-domain>`
+
+For the current Facture-style domains that means infra can set hosts such as
+`ospere.facture.dev.govciocentralplatform.com`,
+`ospere.facture.test.govciocentralplatform.com`, and
+`ospere.facture.govciocentralplatform.com`.

--- a/charts/ospere/ci/all-values.yaml
+++ b/charts/ospere/ci/all-values.yaml
@@ -1,0 +1,42 @@
+ospere:
+  allowedHosts: "ospere.example.com"
+  csrfTrustedOrigins: "https://ospere.example.com"
+  mef:
+    environment: "ats"
+    clientSystemID: "client-system"
+    etin: "12345"
+    endpointURL: "https://example.com/mef"
+    cert:
+      secretName: "ospere-mef-cert"
+
+aws:
+  s3:
+    artifactsBucket: "ospere-artifacts"
+    schemasBucket: "ospere-schemas"
+
+database:
+  host: "postgres.example.com"
+
+secrets:
+  create: true
+  djangoSecretKey:
+    value: "ci-secret-key"
+  postgresPassword:
+    value: "password"
+  celeryBrokerURL:
+    value: "redis://redis:6379/0"
+  celeryResultBackend:
+    value: "django-db"
+
+worker:
+  enabled: true
+
+beat:
+  enabled: true
+
+ingress:
+  enabled: true
+  hosts:
+    - host: ospere.example.com
+      paths:
+        - path: /

--- a/charts/ospere/ci/all-values.yaml
+++ b/charts/ospere/ci/all-values.yaml
@@ -4,7 +4,9 @@ ospere:
   mef:
     environment: "ats"
     clientSystemID: "client-system"
+    efin: "123456"
     etin: "12345"
+    softwareID: "11122233"
     endpointURL: "https://example.com/mef"
     cert:
       secretName: "ospere-mef-cert"

--- a/charts/ospere/templates/NOTES.txt
+++ b/charts/ospere/templates/NOTES.txt
@@ -1,0 +1,8 @@
+Ospere has been deployed.
+
+Service:
+  {{ include "ospere.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+Probes:
+  Liveness:  /livez
+  Readiness: /readyz

--- a/charts/ospere/templates/_environment.tpl
+++ b/charts/ospere/templates/_environment.tpl
@@ -2,11 +2,12 @@
 Ospere pods are configured primarily through environment variables.
 */}}
 {{- define "ospere.environment" -}}
-{{- if and .Values.worker.enabled (not (or .Values.secrets.celeryBrokerURL.name .Values.secrets.celeryBrokerURL.value)) -}}
-{{- fail "worker.enabled requires secrets.celeryBrokerURL.name or secrets.celeryBrokerURL.value" -}}
+{{- $celeryBrokerConfigured := or (and .Values.secrets.create .Values.secrets.celeryBrokerURL.value) (and (not .Values.secrets.create) .Values.secrets.celeryBrokerURL.name) -}}
+{{- if and .Values.worker.enabled (not $celeryBrokerConfigured) -}}
+{{- fail "worker.enabled requires secrets.celeryBrokerURL.value when secrets.create is true, or secrets.celeryBrokerURL.name when secrets.create is false" -}}
 {{- end -}}
-{{- if and .Values.beat.enabled (not (or .Values.secrets.celeryBrokerURL.name .Values.secrets.celeryBrokerURL.value)) -}}
-{{- fail "beat.enabled requires secrets.celeryBrokerURL.name or secrets.celeryBrokerURL.value" -}}
+{{- if and .Values.beat.enabled (not $celeryBrokerConfigured) -}}
+{{- fail "beat.enabled requires secrets.celeryBrokerURL.value when secrets.create is true, or secrets.celeryBrokerURL.name when secrets.create is false" -}}
 {{- end -}}
 env:
   # Django
@@ -96,14 +97,14 @@ env:
   {{- end }}
 
   # Celery
-  {{- if or .Values.secrets.celeryBrokerURL.name .Values.secrets.celeryBrokerURL.value }}
+  {{- if $celeryBrokerConfigured }}
   - name: CELERY_BROKER_URL
     valueFrom:
       secretKeyRef:
         name: {{ include "ospere.celeryBrokerURLSecretName" . }}
         key: {{ .Values.secrets.celeryBrokerURL.key | quote }}
   {{- end }}
-  {{- if or .Values.secrets.celeryResultBackend.name .Values.secrets.celeryResultBackend.value }}
+  {{- if or (and .Values.secrets.create .Values.secrets.celeryResultBackend.value) (and (not .Values.secrets.create) .Values.secrets.celeryResultBackend.name) }}
   - name: CELERY_RESULT_BACKEND
     valueFrom:
       secretKeyRef:

--- a/charts/ospere/templates/_environment.tpl
+++ b/charts/ospere/templates/_environment.tpl
@@ -1,0 +1,113 @@
+{{/*
+Ospere pods are configured primarily through environment variables.
+*/}}
+{{- define "ospere.environment" -}}
+{{- if and .Values.worker.enabled (not (or .Values.secrets.celeryBrokerURL.name .Values.secrets.celeryBrokerURL.value)) -}}
+{{- fail "worker.enabled requires secrets.celeryBrokerURL.name or secrets.celeryBrokerURL.value" -}}
+{{- end -}}
+{{- if and .Values.beat.enabled (not (or .Values.secrets.celeryBrokerURL.name .Values.secrets.celeryBrokerURL.value)) -}}
+{{- fail "beat.enabled requires secrets.celeryBrokerURL.name or secrets.celeryBrokerURL.value" -}}
+{{- end -}}
+env:
+  # Django
+  - name: DJANGO_SETTINGS_MODULE
+    value: {{ .Values.ospere.djangoSettingsModule | quote }}
+  - name: DJANGO_DEBUG
+    value: {{ .Values.ospere.debug | quote }}
+  - name: DJANGO_SECRET_KEY
+    valueFrom:
+      secretKeyRef:
+        name: {{ include "ospere.djangoSecretKeySecretName" . }}
+        key: {{ .Values.secrets.djangoSecretKey.key | quote }}
+  - name: POSTGRES_DB
+    value: {{ .Values.database.name | quote }}
+  - name: POSTGRES_USER
+    value: {{ .Values.database.user | quote }}
+  - name: POSTGRES_HOST
+    value: {{ required "database.host is required" .Values.database.host | quote }}
+  - name: POSTGRES_PORT
+    value: {{ .Values.database.port | quote }}
+  - name: POSTGRES_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: {{ include "ospere.postgresPasswordSecretName" . }}
+        key: {{ .Values.secrets.postgresPassword.key | quote }}
+  {{- if .Values.ospere.allowedHosts }}
+  - name: ALLOWED_HOSTS
+    value: {{ .Values.ospere.allowedHosts | quote }}
+  {{- end }}
+  {{- if .Values.ospere.csrfTrustedOrigins }}
+  - name: CSRF_TRUSTED_ORIGINS
+    value: {{ .Values.ospere.csrfTrustedOrigins | quote }}
+  {{- end }}
+
+  # AWS/S3-compatible storage
+  - name: AWS_DEFAULT_REGION
+    value: {{ .Values.aws.region | quote }}
+  - name: AWS_S3_REGION_NAME
+    value: {{ .Values.aws.region | quote }}
+  - name: OSPERE_STORAGE_BACKEND
+    value: {{ .Values.ospere.storageBackend | quote }}
+  - name: OSPERE_LOCAL_STORAGE_ROOT
+    value: {{ .Values.ospere.localStorageRoot | quote }}
+  - name: OSPERE_ARTIFACTS_BUCKET
+    value: {{ required "aws.s3.artifactsBucket is required" .Values.aws.s3.artifactsBucket | quote }}
+  - name: OSPERE_SCHEMAS_BUCKET
+    value: {{ .Values.aws.s3.schemasBucket | default .Values.aws.s3.artifactsBucket | quote }}
+  - name: AWS_QUERYSTRING_EXPIRE
+    value: {{ .Values.ospere.awsQuerystringExpire | default 3600 | quote }}
+  {{- if .Values.aws.endpointUrl }}
+  - name: AWS_S3_ENDPOINT_URL
+    value: {{ .Values.aws.endpointUrl | quote }}
+  {{- end }}
+
+  # MeF
+  - name: MEF_ENVIRONMENT
+    value: {{ .Values.ospere.mef.environment | quote }}
+  {{- if .Values.ospere.mef.clientSystemID }}
+  - name: MEF_CLIENT_SYSTEM_ID
+    value: {{ .Values.ospere.mef.clientSystemID | quote }}
+  {{- end }}
+  {{- if .Values.ospere.mef.etin }}
+  - name: MEF_ETIN
+    value: {{ .Values.ospere.mef.etin | quote }}
+  {{- end }}
+  {{- if .Values.ospere.mef.endpointURL }}
+  - name: MEF_ENDPOINT_URL
+    value: {{ .Values.ospere.mef.endpointURL | quote }}
+  {{- end }}
+  - name: MEF_MSI_WSDL
+    value: {{ .Values.ospere.mef.msiWSDL | quote }}
+  - name: MEF_TRANSMITTER_WSDL
+    value: {{ .Values.ospere.mef.transmitterWSDL | quote }}
+  {{- if .Values.ospere.mef.cert.secretName }}
+  - name: MEF_CERT_PATH
+    value: {{ printf "%s/%s" .Values.ospere.mef.cert.mountPath .Values.ospere.mef.cert.certKey | quote }}
+  - name: MEF_CERT_KEY_PATH
+    value: {{ printf "%s/%s" .Values.ospere.mef.cert.mountPath .Values.ospere.mef.cert.privateKeyKey | quote }}
+  {{- end }}
+
+  # Celery
+  {{- if or .Values.secrets.celeryBrokerURL.name .Values.secrets.celeryBrokerURL.value }}
+  - name: CELERY_BROKER_URL
+    valueFrom:
+      secretKeyRef:
+        name: {{ include "ospere.celeryBrokerURLSecretName" . }}
+        key: {{ .Values.secrets.celeryBrokerURL.key | quote }}
+  {{- end }}
+  {{- if or .Values.secrets.celeryResultBackend.name .Values.secrets.celeryResultBackend.value }}
+  - name: CELERY_RESULT_BACKEND
+    valueFrom:
+      secretKeyRef:
+        name: {{ include "ospere.celeryResultBackendSecretName" . }}
+        key: {{ .Values.secrets.celeryResultBackend.key | quote }}
+  {{- end }}
+
+  # Application
+  - name: LOG_LEVEL
+    value: {{ .Values.ospere.logLevel | default "INFO" | quote }}
+
+  # OpenTelemetry — configured via Instrumentation CRD (auto-instrumentation)
+  # The ADOT operator injects OTEL env vars automatically when the pod annotation
+  # instrumentation.opentelemetry.io/inject-python: "true" is present.
+{{- end -}}

--- a/charts/ospere/templates/_environment.tpl
+++ b/charts/ospere/templates/_environment.tpl
@@ -68,9 +68,17 @@ env:
   - name: MEF_CLIENT_SYSTEM_ID
     value: {{ .Values.ospere.mef.clientSystemID | quote }}
   {{- end }}
+  {{- if .Values.ospere.mef.efin }}
+  - name: MEF_EFIN
+    value: {{ .Values.ospere.mef.efin | quote }}
+  {{- end }}
   {{- if .Values.ospere.mef.etin }}
   - name: MEF_ETIN
     value: {{ .Values.ospere.mef.etin | quote }}
+  {{- end }}
+  {{- if .Values.ospere.mef.softwareID }}
+  - name: MEF_SOFTWARE_ID
+    value: {{ .Values.ospere.mef.softwareID | quote }}
   {{- end }}
   {{- if .Values.ospere.mef.endpointURL }}
   - name: MEF_ENDPOINT_URL

--- a/charts/ospere/templates/_helpers.tpl
+++ b/charts/ospere/templates/_helpers.tpl
@@ -1,0 +1,93 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ospere.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "ospere.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ospere.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ospere.labels" -}}
+helm.sh/chart: {{ include "ospere.chart" . }}
+{{ include "ospere.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ospere.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ospere.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "ospere.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ .Values.serviceAccount.name | default (include "ospere.fullname" .) }}
+{{- else -}}
+default
+{{- end -}}
+{{- end -}}
+
+{{- define "ospere.djangoSecretKeySecretName" -}}
+{{- if .Values.secrets.create -}}
+{{ include "ospere.fullname" . }}
+{{- else -}}
+{{ default (include "ospere.fullname" .) .Values.secrets.djangoSecretKey.name }}
+{{- end -}}
+{{- end -}}
+
+{{- define "ospere.postgresPasswordSecretName" -}}
+{{- if .Values.secrets.create -}}
+{{ include "ospere.fullname" . }}
+{{- else -}}
+{{ default (include "ospere.fullname" .) .Values.secrets.postgresPassword.name }}
+{{- end -}}
+{{- end -}}
+
+{{- define "ospere.celeryBrokerURLSecretName" -}}
+{{- if .Values.secrets.create -}}
+{{ include "ospere.fullname" . }}
+{{- else -}}
+{{ .Values.secrets.celeryBrokerURL.name }}
+{{- end -}}
+{{- end -}}
+
+{{- define "ospere.celeryResultBackendSecretName" -}}
+{{- if .Values.secrets.create -}}
+{{ include "ospere.fullname" . }}
+{{- else -}}
+{{ .Values.secrets.celeryResultBackend.name }}
+{{- end -}}
+{{- end -}}
+
+{{- define "ospere.image" -}}
+{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+{{- end -}}

--- a/charts/ospere/templates/celery-beat.yaml
+++ b/charts/ospere/templates/celery-beat.yaml
@@ -1,0 +1,79 @@
+{{- if .Values.beat.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ospere.fullname" . }}-beat
+  labels:
+    {{- include "ospere.labels" . | nindent 4 }}
+    app.kubernetes.io/component: beat
+spec:
+  replicas: {{ .Values.beat.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "ospere.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: beat
+  template:
+    metadata:
+      annotations:
+        instrumentation.opentelemetry.io/inject-python: "true"
+        {{- with .Values.pod.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "ospere.labels" . | nindent 8 }}
+        app.kubernetes.io/component: beat
+        {{- with .Values.pod.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "ospere.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.pod.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}-beat
+          image: "{{ include "ospere.image" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.containers.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            {{- toYaml .Values.beat.command | nindent 12 }}
+          args:
+            {{- toYaml .Values.beat.args | nindent 12 }}
+          {{- include "ospere.environment" . | nindent 10 }}
+          {{- with .Values.beat.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.ospere.mef.cert.secretName }}
+          volumeMounts:
+            - name: mef-cert
+              mountPath: {{ .Values.ospere.mef.cert.mountPath | quote }}
+              readOnly: true
+          {{- end }}
+      {{- if .Values.ospere.mef.cert.secretName }}
+      volumes:
+        - name: mef-cert
+          secret:
+            secretName: {{ .Values.ospere.mef.cert.secretName | quote }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/ospere/templates/celery-worker.yaml
+++ b/charts/ospere/templates/celery-worker.yaml
@@ -1,0 +1,79 @@
+{{- if .Values.worker.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ospere.fullname" . }}-worker
+  labels:
+    {{- include "ospere.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  replicas: {{ .Values.worker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "ospere.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+  template:
+    metadata:
+      annotations:
+        instrumentation.opentelemetry.io/inject-python: "true"
+        {{- with .Values.pod.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "ospere.labels" . | nindent 8 }}
+        app.kubernetes.io/component: worker
+        {{- with .Values.pod.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "ospere.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.pod.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}-worker
+          image: "{{ include "ospere.image" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.containers.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            {{- toYaml .Values.worker.command | nindent 12 }}
+          args:
+            {{- toYaml .Values.worker.args | nindent 12 }}
+          {{- include "ospere.environment" . | nindent 10 }}
+          {{- with .Values.worker.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.ospere.mef.cert.secretName }}
+          volumeMounts:
+            - name: mef-cert
+              mountPath: {{ .Values.ospere.mef.cert.mountPath | quote }}
+              readOnly: true
+          {{- end }}
+      {{- if .Values.ospere.mef.cert.secretName }}
+      volumes:
+        - name: mef-cert
+          secret:
+            secretName: {{ .Values.ospere.mef.cert.secretName | quote }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/ospere/templates/deployment.yaml
+++ b/charts/ospere/templates/deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ospere.fullname" . }}
+  labels:
+    {{- include "ospere.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "ospere.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      annotations:
+        instrumentation.opentelemetry.io/inject-python: "true"
+        {{- with .Values.pod.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "ospere.labels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+        {{- with .Values.pod.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "ospere.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.pod.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ include "ospere.image" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.containers.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.web.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.web.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- include "ospere.environment" . | nindent 10 }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.ospere.mef.cert.secretName }}
+          volumeMounts:
+            - name: mef-cert
+              mountPath: {{ .Values.ospere.mef.cert.mountPath | quote }}
+              readOnly: true
+          {{- end }}
+      {{- if .Values.ospere.mef.cert.secretName }}
+      volumes:
+        - name: mef-cert
+          secret:
+            secretName: {{ .Values.ospere.mef.cert.secretName | quote }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/ospere/templates/ingress.yaml
+++ b/charts/ospere/templates/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ospere.fullname" . }}
+  labels:
+    {{- include "ospere.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "ospere.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/ospere/templates/jobs.yaml
+++ b/charts/ospere/templates/jobs.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.jobs.migrate.create -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "ospere.fullname" . }}-migrate
+  labels:
+    {{- include "ospere.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migrate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "8"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "ospere.labels" . | nindent 8 }}
+        app.kubernetes.io/component: migrate
+    spec:
+      serviceAccountName: {{ include "ospere.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.pod.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}-migrate
+          image: "{{ include "ospere.image" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.containers.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command: ["python", "manage.py", "migrate", "--noinput"]
+          {{- include "ospere.environment" . | nindent 10 }}
+          {{- if .Values.ospere.mef.cert.secretName }}
+          volumeMounts:
+            - name: mef-cert
+              mountPath: {{ .Values.ospere.mef.cert.mountPath | quote }}
+              readOnly: true
+          {{- end }}
+      {{- if .Values.ospere.mef.cert.secretName }}
+      volumes:
+        - name: mef-cert
+          secret:
+            secretName: {{ .Values.ospere.mef.cert.secretName | quote }}
+      {{- end }}
+      restartPolicy: Never
+  backoffLimit: {{ .Values.jobs.migrate.backoffLimit | default 5 }}
+{{- end -}}

--- a/charts/ospere/templates/secret.yaml
+++ b/charts/ospere/templates/secret.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.secrets.create -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ospere.fullname" . }}
+  labels:
+    {{- include "ospere.labels" . | nindent 4 }}
+data:
+  {{- if .Values.secrets.djangoSecretKey.value }}
+  {{ .Values.secrets.djangoSecretKey.key }}: {{ .Values.secrets.djangoSecretKey.value | b64enc }}
+  {{- end }}
+  {{- if .Values.secrets.postgresPassword.value }}
+  {{ .Values.secrets.postgresPassword.key }}: {{ .Values.secrets.postgresPassword.value | b64enc }}
+  {{- end }}
+  {{- if .Values.secrets.celeryBrokerURL.value }}
+  {{ .Values.secrets.celeryBrokerURL.key }}: {{ .Values.secrets.celeryBrokerURL.value | b64enc }}
+  {{- end }}
+  {{- if .Values.secrets.celeryResultBackend.value }}
+  {{ .Values.secrets.celeryResultBackend.key }}: {{ .Values.secrets.celeryResultBackend.value | b64enc }}
+  {{- end }}
+{{- end }}

--- a/charts/ospere/templates/service.yaml
+++ b/charts/ospere/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ospere.fullname" . }}
+  labels:
+    {{- include "ospere.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "ospere.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web

--- a/charts/ospere/templates/serviceaccount.yaml
+++ b/charts/ospere/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name | default (include "ospere.fullname" .) }}
+  labels:
+    {{- include "ospere.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/ospere/templates/tests/test-connection.yaml
+++ b/charts/ospere/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "ospere.fullname" . }}-test-connection"
+  labels:
+    {{- include "ospere.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ["wget"]
+      args: ["{{ include "ospere.fullname" . }}:{{ .Values.service.port }}/livez"]
+  restartPolicy: Never

--- a/charts/ospere/values.yaml
+++ b/charts/ospere/values.yaml
@@ -17,7 +17,9 @@ ospere:
   mef:
     environment: "ats"
     clientSystemID: ""
+    efin: ""
     etin: ""
+    softwareID: ""
     endpointURL: ""
     msiWSDL: "wsdl/MeFMSIServices.wsdl"
     transmitterWSDL: "wsdl/MeFTransmitterServicesMTOM.wsdl"

--- a/charts/ospere/values.yaml
+++ b/charts/ospere/values.yaml
@@ -1,0 +1,138 @@
+# Default values for ospere.
+
+nameOverride: ""
+fullnameOverride: ""
+
+replicaCount: 1
+
+ospere:
+  logLevel: "INFO"
+  djangoSettingsModule: "ospere.settings.prod"
+  debug: false
+  allowedHosts: ""
+  csrfTrustedOrigins: ""
+  storageBackend: "s3"
+  localStorageRoot: "/app/storage/artifacts"
+  awsQuerystringExpire: 3600
+  mef:
+    environment: "ats"
+    clientSystemID: ""
+    etin: ""
+    endpointURL: ""
+    msiWSDL: "wsdl/MeFMSIServices.wsdl"
+    transmitterWSDL: "wsdl/MeFTransmitterServicesMTOM.wsdl"
+    cert:
+      secretName: ""
+      mountPath: "/var/run/ospere/mef"
+      certKey: "cert.pem"
+      privateKeyKey: "key.pem"
+
+web:
+  command: []
+  args: []
+
+worker:
+  enabled: false
+  replicaCount: 1
+  command: ["celery"]
+  args: ["-A", "ospere", "worker", "--loglevel=INFO"]
+  resources: {}
+
+beat:
+  enabled: false
+  replicaCount: 1
+  command: ["celery"]
+  args: ["-A", "ospere", "beat", "--loglevel=INFO"]
+  resources: {}
+
+aws:
+  region: us-east-2
+  s3:
+    artifactsBucket: ""
+    schemasBucket: ""
+  endpointUrl: ""
+
+database:
+  name: "ospere"
+  user: "postgres"
+  host: ""
+  port: "5432"
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+secrets:
+  create: false
+  djangoSecretKey:
+    name: ""
+    key: "django-secret-key"
+    value: ""
+  postgresPassword:
+    name: ""
+    key: "postgres-password"
+    value: ""
+  celeryBrokerURL:
+    name: ""
+    key: "celery-broker-url"
+    value: ""
+  celeryResultBackend:
+    name: ""
+    key: "celery-result-backend"
+    value: ""
+
+jobs:
+  migrate:
+    create: true
+    backoffLimit: 3
+
+image:
+  repository: 595425361112.dkr.ecr.us-east-2.amazonaws.com/ospere
+  pullPolicy: Always
+  tag: ""
+
+imagePullSecrets: []
+
+pod:
+  annotations: {}
+  labels: {}
+  securityContext: {}
+
+containers:
+  securityContext: {}
+
+service:
+  type: ClusterIP
+  port: 8000
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts: []
+
+livenessProbe:
+  httpGet:
+    path: /livez
+    port: 8000
+    httpHeaders:
+    - name: X-Kubernetes-Probe
+      value: liveness
+  initialDelaySeconds: 2
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: 8000
+    httpHeaders:
+    - name: X-Kubernetes-Probe
+      value: readiness
+  initialDelaySeconds: 2
+  periodSeconds: 10
+
+resources: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
### Scope of changes

Adds a new `ospere` application chart for the Django-based IRS MeF filing service. The chart includes:

- web Deployment, Service, ServiceAccount, Secret support, optional Ingress, Helm test pod, and migration hook Job
- Ospere runtime env wiring for Django settings, Postgres, S3-compatible storage, MeF A2A config, and optional certificate/private-key mount
- MeF config values for environment, endpoint, WSDLs, AppSysID, EFIN, ETIN, and software ID
- disabled-by-default Celery worker and beat Deployments that reuse the same image and environment
- `ci/all-values.yaml` for full chart rendering coverage
- README entry in the root chart index and an Ospere chart README with expected host naming notes

Note: the chart now renders `MEF_SOFTWARE_ID`, but the Ospere app still needs an app-side change to read that env var before it affects runtime behavior.

### Type of change

- [ ] update app version
- [x] new objects/feature
- [x] new/additional configuration
- [x] documentation
- [ ] other (describe)

### Author checklist

- [x] I have manually debugged the charts using `helm debug`
- [x] I have updated any affected `values.schema.json` files
- [x] I have updated the Chart Version for any affected charts

No `values.schema.json` exists for these charts, so there was no schema file to update. This introduces chart version `0.1.0` for the new `ospere` chart.

Proof:

```sh
helm lint charts/*
helm template ospere charts/ospere -f charts/ospere/ci/all-values.yaml
```

Additional rendered contract check verified the web Deployment includes `MEF_CLIENT_SYSTEM_ID`, `MEF_EFIN`, `MEF_ETIN`, `MEF_SOFTWARE_ID`, `MEF_ENDPOINT_URL`, `MEF_CERT_PATH`, and `MEF_CERT_KEY_PATH`.