### PR TITLE
Add Ospere logging component environment

### DIFF
--- a/charts/ospere/Chart.yaml
+++ b/charts/ospere/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ospere
 description: Django service for IRS MeF filing orchestration, schema validation, and filing lifecycle state.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"
 home: https://kungfu.ai
 icon: https://cdn.prod.website-files.com/626ff088dc91e832fe2f3249/680e74ec5378b7b440b03b0c_32x32.png

--- a/charts/ospere/templates/_environment.tpl
+++ b/charts/ospere/templates/_environment.tpl
@@ -122,3 +122,11 @@ env:
   # The ADOT operator injects OTEL env vars automatically when the pod annotation
   # instrumentation.opentelemetry.io/inject-python: "true" is present.
 {{- end -}}
+
+{{/*
+Structured logging component label for a specific Ospere workload.
+*/}}
+{{- define "ospere.serviceComponentEnv" -}}
+- name: OSPERE_SERVICE_COMPONENT
+  value: {{ .component | quote }}
+{{- end -}}

--- a/charts/ospere/templates/_environment.tpl
+++ b/charts/ospere/templates/_environment.tpl
@@ -113,6 +113,8 @@ env:
   {{- end }}
 
   # Application
+  - name: OSPERE_ENVIRONMENT
+    value: {{ .Values.ospere.runtimeEnvironment | default .Release.Namespace | quote }}
   - name: LOG_LEVEL
     value: {{ .Values.ospere.logLevel | default "INFO" | quote }}
 

--- a/charts/ospere/templates/celery-beat.yaml
+++ b/charts/ospere/templates/celery-beat.yaml
@@ -48,8 +48,7 @@ spec:
           args:
             {{- toYaml .Values.beat.args | nindent 12 }}
           {{- include "ospere.environment" . | nindent 10 }}
-            - name: OSPERE_SERVICE_COMPONENT
-              value: "celery.beat"
+            {{- include "ospere.serviceComponentEnv" (dict "component" "celery.beat") | nindent 12 }}
           {{- with .Values.beat.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/ospere/templates/celery-beat.yaml
+++ b/charts/ospere/templates/celery-beat.yaml
@@ -48,6 +48,8 @@ spec:
           args:
             {{- toYaml .Values.beat.args | nindent 12 }}
           {{- include "ospere.environment" . | nindent 10 }}
+            - name: OSPERE_SERVICE_COMPONENT
+              value: "celery.beat"
           {{- with .Values.beat.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/ospere/templates/celery-worker.yaml
+++ b/charts/ospere/templates/celery-worker.yaml
@@ -48,8 +48,7 @@ spec:
           args:
             {{- toYaml .Values.worker.args | nindent 12 }}
           {{- include "ospere.environment" . | nindent 10 }}
-            - name: OSPERE_SERVICE_COMPONENT
-              value: "celery.worker"
+            {{- include "ospere.serviceComponentEnv" (dict "component" "celery.worker") | nindent 12 }}
           {{- with .Values.worker.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/ospere/templates/celery-worker.yaml
+++ b/charts/ospere/templates/celery-worker.yaml
@@ -48,6 +48,8 @@ spec:
           args:
             {{- toYaml .Values.worker.args | nindent 12 }}
           {{- include "ospere.environment" . | nindent 10 }}
+            - name: OSPERE_SERVICE_COMPONENT
+              value: "celery.worker"
           {{- with .Values.worker.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/ospere/templates/deployment.yaml
+++ b/charts/ospere/templates/deployment.yaml
@@ -55,8 +55,7 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           {{- include "ospere.environment" . | nindent 10 }}
-            - name: OSPERE_SERVICE_COMPONENT
-              value: "web"
+            {{- include "ospere.serviceComponentEnv" (dict "component" "web") | nindent 12 }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/ospere/templates/deployment.yaml
+++ b/charts/ospere/templates/deployment.yaml
@@ -55,6 +55,8 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           {{- include "ospere.environment" . | nindent 10 }}
+            - name: OSPERE_SERVICE_COMPONENT
+              value: "web"
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/ospere/templates/jobs.yaml
+++ b/charts/ospere/templates/jobs.yaml
@@ -36,8 +36,7 @@ spec:
           {{- end }}
           command: ["python", "manage.py", "migrate", "--noinput"]
           {{- include "ospere.environment" . | nindent 10 }}
-            - name: OSPERE_SERVICE_COMPONENT
-              value: "job.migrate"
+            {{- include "ospere.serviceComponentEnv" (dict "component" "job.migrate") | nindent 12 }}
           {{- if .Values.ospere.mef.cert.secretName }}
           volumeMounts:
             - name: mef-cert

--- a/charts/ospere/templates/jobs.yaml
+++ b/charts/ospere/templates/jobs.yaml
@@ -36,6 +36,8 @@ spec:
           {{- end }}
           command: ["python", "manage.py", "migrate", "--noinput"]
           {{- include "ospere.environment" . | nindent 10 }}
+            - name: OSPERE_SERVICE_COMPONENT
+              value: "job.migrate"
           {{- if .Values.ospere.mef.cert.secretName }}
           volumeMounts:
             - name: mef-cert

--- a/charts/ospere/values.yaml
+++ b/charts/ospere/values.yaml
@@ -7,6 +7,9 @@ replicaCount: 1
 
 ospere:
   logLevel: "INFO"
+  # Runtime environment label for structured logs. If unset, the chart uses the
+  # release namespace.
+  runtimeEnvironment: ""
   djangoSettingsModule: "ospere.settings.prod"
   debug: false
   allowedHosts: ""

--- a/charts/ospere/values.yaml
+++ b/charts/ospere/values.yaml
@@ -7,8 +7,8 @@ replicaCount: 1
 
 ospere:
   logLevel: "INFO"
-  # Runtime environment label for structured logs. If unset, the chart uses the
-  # release namespace.
+  # Runtime environment label for structured logs. If empty or unset, the chart
+  # uses the release namespace.
   runtimeEnvironment: ""
   djangoSettingsModule: "ospere.settings.prod"
   debug: false


### PR DESCRIPTION
### Scope of changes

Updates the Ospere chart to pass structured logging runtime labels into each workload. The shared environment now sets `OSPERE_ENVIRONMENT`, defaulting to the release namespace unless `ospere.runtimeEnvironment` is provided. Each workload sets `OSPERE_SERVICE_COMPONENT` so logs can distinguish `web`, `celery.worker`, `celery.beat`, and `job.migrate`. The Ospere chart version is bumped to `0.1.1`.

### Type of change

- [ ] update app version
- [ ] new objects/feature
- [x] new/additional configuration
- [ ] documentation
- [ ] other (describe)

### Author checklist

- [x] I have manually debugged the charts using `helm debug`
- [ ] I have updated any affected `values.schema.json` files
- [x] I have updated the Chart Version for any affected charts

Proof run locally:

```sh
helm lint charts/ospere -f charts/ospere/ci/all-values.yaml
helm template --debug ospere charts/ospere -f charts/ospere/ci/all-values.yaml
helm template ospere charts/ospere -f charts/ospere/ci/all-values.yaml | awk '/name: OSPERE_SERVICE_COMPONENT/{print; getline; print} /name: OSPERE_ENVIRONMENT/{print; getline; print}'\n```\n\nRendered components: `web`, `celery.worker`, `celery.beat`, `job.migrate`.\n\nNote: this chart does not currently have a `values.schema.json`, so there was no schema file to update.\n