### PR TITLE
Fix Ospere migration service account hook

### DIFF
--- a/.github/workflows/chart-contract.yaml
+++ b/.github/workflows/chart-contract.yaml
@@ -52,3 +52,36 @@ jobs:
           raise "worker deployment still emits livenessProbe" if container.key?("livenessProbe")
           raise "worker deployment still emits readinessProbe" if container.key?("readinessProbe")
           RUBY
+
+      - name: Validate Ospere migration hook service account contract
+        run: |
+          rendered="$(mktemp)"
+          helm template ospere ./charts/ospere \
+            --namespace ospere \
+            -f ./charts/ospere/ci/all-values.yaml \
+            >"${rendered}"
+
+          ruby - "${rendered}" <<'RUBY'
+          require "yaml"
+
+          path = ARGV.fetch(0)
+          docs = YAML.load_stream(File.read(path))
+          migration = docs.find do |doc|
+            doc.is_a?(Hash) && doc["kind"] == "Job" && doc.dig("metadata", "name") == "ospere-migrate"
+          end
+
+          raise "ospere migration job missing from rendered chart" if migration.nil?
+
+          pod_spec = migration.dig("spec", "template", "spec")
+          raise "ospere migration pod spec missing from rendered chart" if pod_spec.nil?
+
+          if pod_spec.key?("serviceAccountName")
+            raise "ospere pre-install migration hook must not reference chart-created serviceAccountName by default"
+          end
+
+          service_account = docs.find do |doc|
+            doc.is_a?(Hash) && doc["kind"] == "ServiceAccount" && doc.dig("metadata", "name") == "ospere"
+          end
+
+          raise "ospere runtime service account missing from rendered chart" if service_account.nil?
+          RUBY

--- a/charts/ospere/Chart.yaml
+++ b/charts/ospere/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ospere
 description: Django service for IRS MeF filing orchestration, schema validation, and filing lifecycle state.
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "0.1.0"
 home: https://kungfu.ai
 icon: https://cdn.prod.website-files.com/626ff088dc91e832fe2f3249/680e74ec5378b7b440b03b0c_32x32.png

--- a/charts/ospere/README.md
+++ b/charts/ospere/README.md
@@ -13,6 +13,11 @@ The chart follows the same service pattern as the existing Facture charts:
 
 Celery workloads are disabled by default until the filing lifecycle moves to asynchronous jobs.
 
+The migration hook intentionally uses the namespace default ServiceAccount unless
+`jobs.migrate.serviceAccountName` is explicitly set. Pre-install hooks run before
+normal chart resources, so referencing the chart-created Ospere ServiceAccount
+would break first installs.
+
 MeF A2A configuration requires more than the mounted certificate. The chart exposes
 the X.509 cert path, private key path, `AppSysID` (`MEF_CLIENT_SYSTEM_ID`), EFIN,
 ETIN, software ID, endpoint, environment, and WSDL paths. The application must also

--- a/charts/ospere/templates/jobs.yaml
+++ b/charts/ospere/templates/jobs.yaml
@@ -17,7 +17,9 @@ spec:
         {{- include "ospere.labels" . | nindent 8 }}
         app.kubernetes.io/component: migrate
     spec:
-      serviceAccountName: {{ include "ospere.serviceAccountName" . }}
+      {{- if .Values.jobs.migrate.serviceAccountName }}
+      serviceAccountName: {{ .Values.jobs.migrate.serviceAccountName | quote }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/ospere/values.yaml
+++ b/charts/ospere/values.yaml
@@ -91,6 +91,9 @@ jobs:
   migrate:
     create: true
     backoffLimit: 3
+    # Pre-install/pre-upgrade migration hooks run before normal chart resources.
+    # Leave empty so first installs can use the namespace default ServiceAccount.
+    serviceAccountName: ""
 
 image:
   repository: 595425361112.dkr.ecr.us-east-2.amazonaws.com/ospere


### PR DESCRIPTION
### Scope of changes

Fixes the Ospere migration hook so first installs do not reference the chart-created `ServiceAccount/ospere` before Helm has created normal chart resources.

Changes:
- Ospere migration hook uses the namespace default ServiceAccount by default.
- Adds optional `jobs.migrate.serviceAccountName` override for explicit hook ServiceAccount use.
- Keeps web/worker/beat on the chart-created Ospere ServiceAccount.
- Adds chart contract coverage for the first-install migration hook invariant.
- Bumps Ospere chart version to `0.1.2`.

This fixes the sandbox deploy failure:

`pods "ospere-migrate-" is forbidden: error looking up service account ospere/ospere: serviceaccount "ospere" not found`

### Type of change

- [x] update app version
- [ ] new objects/feature
- [x] new/additional configuration
- [x] documentation
- [x] other (describe)

Chart hook ordering fix.

### Author checklist

- [x] I have manually debugged the charts using `helm debug`
- [x] I have updated any affected `values.schema.json` files
- [x] I have updated the Chart Version for any affected charts

No `values.schema.json` exists for the Ospere chart.

Proof:

```bash
helm lint charts/ospere
rendered=$(mktemp) && helm template ospere ./charts/ospere --namespace ospere -f ./charts/ospere/ci/all-values.yaml >"$rendered"
for chart in charts/*; do helm lint "$chart"; done
```
