### PR TITLE
Use locked Ospere migration hooks

### DIFF
--- a/.github/workflows/chart-contract.yaml
+++ b/.github/workflows/chart-contract.yaml
@@ -53,12 +53,14 @@ jobs:
           raise "worker deployment still emits readinessProbe" if container.key?("readinessProbe")
           RUBY
 
-      - name: Validate Ospere migration hook service account contract
+      - name: Validate Ospere hook contract
         run: |
           rendered="$(mktemp)"
           helm template ospere ./charts/ospere \
             --namespace ospere \
             -f ./charts/ospere/ci/all-values.yaml \
+            --set jobs.ensureAdmin.create=true \
+            --set jobs.ensureAdmin.existingSecret=ospere-admin-bootstrap \
             >"${rendered}"
 
           ruby - "${rendered}" <<'RUBY'
@@ -72,12 +74,34 @@ jobs:
 
           raise "ospere migration job missing from rendered chart" if migration.nil?
 
+          migration_annotations = migration.dig("metadata", "annotations") || {}
+          raise "ospere migration hook must run before install and upgrade" unless migration_annotations["helm.sh/hook"] == "pre-install,pre-upgrade"
+          raise "ospere migration hook weight must be 8" unless migration_annotations["helm.sh/hook-weight"] == "8"
+
           pod_spec = migration.dig("spec", "template", "spec")
           raise "ospere migration pod spec missing from rendered chart" if pod_spec.nil?
 
           if pod_spec.key?("serviceAccountName")
             raise "ospere pre-install migration hook must not reference chart-created serviceAccountName by default"
           end
+
+          migration_container = pod_spec.dig("containers", 0)
+          raise "ospere migration container missing from rendered chart" if migration_container.nil?
+          raise "ospere migration hook must use lockedmigrate" unless migration_container["command"] == ["python", "manage.py", "lockedmigrate", "--noinput"]
+
+          ensure_admin = docs.find do |doc|
+            doc.is_a?(Hash) && doc["kind"] == "Job" && doc.dig("metadata", "name") == "ospere-ensure-admin"
+          end
+
+          raise "ospere ensure-admin job missing from rendered chart" if ensure_admin.nil?
+
+          ensure_admin_annotations = ensure_admin.dig("metadata", "annotations") || {}
+          raise "ospere ensure-admin hook must run before install and upgrade" unless ensure_admin_annotations["helm.sh/hook"] == "pre-install,pre-upgrade"
+          raise "ospere ensure-admin hook must run after migrations" unless ensure_admin_annotations["helm.sh/hook-weight"] == "16"
+
+          ensure_admin_container = ensure_admin.dig("spec", "template", "spec", "containers", 0)
+          raise "ospere ensure-admin container missing from rendered chart" if ensure_admin_container.nil?
+          raise "ospere ensure-admin hook must use ensureadmin" unless ensure_admin_container["command"] == ["python", "manage.py", "ensureadmin"]
 
           service_account = docs.find do |doc|
             doc.is_a?(Hash) && doc["kind"] == "ServiceAccount" && doc.dig("metadata", "name") == "ospere"

--- a/.github/workflows/chart-contract.yaml
+++ b/.github/workflows/chart-contract.yaml
@@ -99,9 +99,31 @@ jobs:
           raise "ospere ensure-admin hook must run before install and upgrade" unless ensure_admin_annotations["helm.sh/hook"] == "pre-install,pre-upgrade"
           raise "ospere ensure-admin hook must run after migrations" unless ensure_admin_annotations["helm.sh/hook-weight"] == "16"
 
-          ensure_admin_container = ensure_admin.dig("spec", "template", "spec", "containers", 0)
+          ensure_admin_pod_spec = ensure_admin.dig("spec", "template", "spec")
+          raise "ospere ensure-admin pod spec missing from rendered chart" if ensure_admin_pod_spec.nil?
+
+          if ensure_admin_pod_spec.key?("serviceAccountName")
+            raise "ospere pre-install ensure-admin hook must not reference chart-created serviceAccountName by default"
+          end
+
+          ensure_admin_container = ensure_admin_pod_spec.dig("containers", 0)
           raise "ospere ensure-admin container missing from rendered chart" if ensure_admin_container.nil?
           raise "ospere ensure-admin hook must use ensureadmin" unless ensure_admin_container["command"] == ["python", "manage.py", "ensureadmin"]
+
+          admin_env = ensure_admin_container["env"] || []
+          admin_secret_refs = admin_env.each_with_object({}) do |env_var, refs|
+            next unless env_var["name"]&.start_with?("DJANGO_ADMIN_")
+
+            refs[env_var["name"]] = env_var.dig("valueFrom", "secretKeyRef")
+          end
+
+          expected_admin_refs = {
+            "DJANGO_ADMIN_USERNAME" => {"name" => "ospere-admin-bootstrap", "key" => "username"},
+            "DJANGO_ADMIN_EMAIL" => {"name" => "ospere-admin-bootstrap", "key" => "email"},
+            "DJANGO_ADMIN_PASSWORD" => {"name" => "ospere-admin-bootstrap", "key" => "password"},
+          }
+
+          raise "ospere ensure-admin hook must wire DJANGO_ADMIN_* from the bootstrap Secret" unless admin_secret_refs == expected_admin_refs
 
           service_account = docs.find do |doc|
             doc.is_a?(Hash) && doc["kind"] == "ServiceAccount" && doc.dig("metadata", "name") == "ospere"

--- a/charts/ospere/Chart.yaml
+++ b/charts/ospere/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ospere
 description: Django service for IRS MeF filing orchestration, schema validation, and filing lifecycle state.
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "0.1.0"
 home: https://kungfu.ai
 icon: https://cdn.prod.website-files.com/626ff088dc91e832fe2f3249/680e74ec5378b7b440b03b0c_32x32.png

--- a/charts/ospere/README.md
+++ b/charts/ospere/README.md
@@ -5,7 +5,8 @@ Deploys the Ospere Django service for IRS MeF filing orchestration.
 The chart follows the same service pattern as the existing Facture charts:
 
 - Django/Gunicorn web deployment
-- optional Django migration hook job
+- optional Django locked migration hook job
+- optional Django admin bootstrap hook job
 - service account with IRSA annotations
 - database and application secrets by reference
 - optional ingress
@@ -13,10 +14,19 @@ The chart follows the same service pattern as the existing Facture charts:
 
 Celery workloads are disabled by default until the filing lifecycle moves to asynchronous jobs.
 
-The migration hook intentionally uses the namespace default ServiceAccount unless
-`jobs.migrate.serviceAccountName` is explicitly set. Pre-install hooks run before
-normal chart resources, so referencing the chart-created Ospere ServiceAccount
-would break first installs.
+The migration hook runs `python manage.py lockedmigrate --noinput` as a
+`pre-install,pre-upgrade` hook. `lockedmigrate` comes from the `django-kubernetes`
+app and uses a Postgres advisory lock so concurrent rollouts or rollbacks do not
+race Django migrations.
+
+The migration and ensure-admin hooks intentionally use the namespace default
+ServiceAccount unless `jobs.*.serviceAccountName` is explicitly set. Pre-install
+hooks run before normal chart resources, so referencing the chart-created Ospere
+ServiceAccount would break first installs.
+
+The ensure-admin hook is disabled by default. When enabled, it runs after locked
+migrations and reads `DJANGO_ADMIN_USERNAME`, `DJANGO_ADMIN_EMAIL`, and
+`DJANGO_ADMIN_PASSWORD` from `jobs.ensureAdmin.existingSecret`.
 
 MeF A2A configuration requires more than the mounted certificate. The chart exposes
 the X.509 cert path, private key path, `AppSysID` (`MEF_CLIENT_SYSTEM_ID`), EFIN,
@@ -32,6 +42,6 @@ GovCIO host pattern is:
 - production: `ospere.<prod-domain>`
 
 For the current Facture-style domains that means infra can set hosts such as
-`ospere.facture.dev.govciocentralplatform.com`,
-`ospere.facture.test.govciocentralplatform.com`, and
-`ospere.facture.govciocentralplatform.com`.
+`ospere.dev.govciocentralplatform.com`,
+`ospere.test.govciocentralplatform.com`, and
+`ospere.govciocentralplatform.com`.

--- a/charts/ospere/README.md
+++ b/charts/ospere/README.md
@@ -42,6 +42,6 @@ GovCIO host pattern is:
 - production: `ospere.<prod-domain>`
 
 For the current Facture-style domains that means infra can set hosts such as
-`ospere.dev.govciocentralplatform.com`,
-`ospere.test.govciocentralplatform.com`, and
-`ospere.govciocentralplatform.com`.
+`ospere.facture.dev.govciocentralplatform.com`,
+`ospere.facture.test.govciocentralplatform.com`, and
+`ospere.facture.govciocentralplatform.com`.

--- a/charts/ospere/templates/jobs.yaml
+++ b/charts/ospere/templates/jobs.yaml
@@ -36,7 +36,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          command: ["python", "manage.py", "migrate", "--noinput"]
+          command: ["python", "manage.py", "lockedmigrate", "--noinput"]
           {{- include "ospere.environment" . | nindent 10 }}
             {{- include "ospere.serviceComponentEnv" (dict "component" "job.migrate") | nindent 12 }}
           {{- if .Values.ospere.mef.cert.secretName }}
@@ -53,4 +53,78 @@ spec:
       {{- end }}
       restartPolicy: Never
   backoffLimit: {{ .Values.jobs.migrate.backoffLimit | default 5 }}
+{{- end }}
+{{- if and .Values.jobs.migrate.create .Values.jobs.ensureAdmin.create }}
+---
+{{- end }}
+{{- if .Values.jobs.ensureAdmin.create }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "ospere.fullname" . }}-ensure-admin
+  labels:
+    {{- include "ospere.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ensure-admin
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "16"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "ospere.labels" . | nindent 8 }}
+        app.kubernetes.io/component: ensure-admin
+    spec:
+      {{- if .Values.jobs.ensureAdmin.serviceAccountName }}
+      serviceAccountName: {{ .Values.jobs.ensureAdmin.serviceAccountName | quote }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.pod.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}-ensure-admin
+          image: "{{ include "ospere.image" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.containers.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command: ["python", "manage.py", "ensureadmin"]
+          {{- include "ospere.environment" . | nindent 10 }}
+            {{- include "ospere.serviceComponentEnv" (dict "component" "job.ensure-admin") | nindent 12 }}
+            - name: DJANGO_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "jobs.ensureAdmin.existingSecret is required when jobs.ensureAdmin.create is true" .Values.jobs.ensureAdmin.existingSecret | quote }}
+                  key: {{ .Values.jobs.ensureAdmin.usernameKey | quote }}
+            - name: DJANGO_ADMIN_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "jobs.ensureAdmin.existingSecret is required when jobs.ensureAdmin.create is true" .Values.jobs.ensureAdmin.existingSecret | quote }}
+                  key: {{ .Values.jobs.ensureAdmin.emailKey | quote }}
+            - name: DJANGO_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "jobs.ensureAdmin.existingSecret is required when jobs.ensureAdmin.create is true" .Values.jobs.ensureAdmin.existingSecret | quote }}
+                  key: {{ .Values.jobs.ensureAdmin.passwordKey | quote }}
+          {{- if .Values.ospere.mef.cert.secretName }}
+          volumeMounts:
+            - name: mef-cert
+              mountPath: {{ .Values.ospere.mef.cert.mountPath | quote }}
+              readOnly: true
+          {{- end }}
+      {{- if .Values.ospere.mef.cert.secretName }}
+      volumes:
+        - name: mef-cert
+          secret:
+            secretName: {{ .Values.ospere.mef.cert.secretName | quote }}
+      {{- end }}
+      restartPolicy: Never
+  backoffLimit: {{ .Values.jobs.ensureAdmin.backoffLimit | default 5 }}
 {{- end -}}

--- a/charts/ospere/values.yaml
+++ b/charts/ospere/values.yaml
@@ -94,6 +94,17 @@ jobs:
     # Pre-install/pre-upgrade migration hooks run before normal chart resources.
     # Leave empty so first installs can use the namespace default ServiceAccount.
     serviceAccountName: ""
+  ensureAdmin:
+    create: false
+    backoffLimit: 3
+    # Pre-install/pre-upgrade admin hooks run after locked migrations.
+    # Leave empty so first installs can use the namespace default ServiceAccount.
+    serviceAccountName: ""
+    # Existing short-lived Secret created by the deployment workflow.
+    existingSecret: ""
+    usernameKey: "username"
+    emailKey: "email"
+    passwordKey: "password"
 
 image:
   repository: 595425361112.dkr.ecr.us-east-2.amazonaws.com/ospere


### PR DESCRIPTION
### Scope of changes

Updates the Ospere chart jobs to use the django-kubernetes hook pattern:

- migration hook now runs `python manage.py lockedmigrate --noinput` as `pre-install,pre-upgrade` with weight `8`
- optional ensure-admin hook runs `python manage.py ensureadmin` as `pre-install,pre-upgrade` with weight `16`
- admin hook reads `DJANGO_ADMIN_USERNAME`, `DJANGO_ADMIN_EMAIL`, and `DJANGO_ADMIN_PASSWORD` from an existing short-lived Secret
- chart contract now asserts hook annotations, ordering, commands, and default service account behavior
- bumps Ospere chart to `0.1.3`

### Type of change

- [ ] update app version
- [x] new objects/feature
- [x] new/additional configuration
- [x] documentation
- [ ] other (describe)

### Author checklist

- [x] I have manually debugged the charts using `helm debug`
- [ ] I have updated any affected `values.schema.json` files
- [x] I have updated the Chart Version for any affected charts

Proof:

- `helm lint charts/ospere`
- `helm template ospere charts/ospere -f charts/ospere/ci/all-values.yaml --set jobs.ensureAdmin.create=true --set jobs.ensureAdmin.existingSecret=ospere-admin-bootstrap`
- `helm install ospere charts/ospere --namespace ospere --dry-run=client --debug -f charts/ospere/ci/all-values.yaml --set jobs.ensureAdmin.create=true --set jobs.ensureAdmin.existingSecret=ospere-admin-bootstrap`
- rendered contract check confirmed `lockedmigrate`, `ensureadmin`, hook weights, and `DJANGO_ADMIN_*` env vars

No `values.schema.json` exists for this chart.