### PR TITLE
Use syncadmin for Ospere admin hook

### DIFF
--- a/.github/workflows/chart-contract.yaml
+++ b/.github/workflows/chart-contract.yaml
@@ -108,7 +108,7 @@ jobs:
 
           ensure_admin_container = ensure_admin_pod_spec.dig("containers", 0)
           raise "ospere ensure-admin container missing from rendered chart" if ensure_admin_container.nil?
-          raise "ospere ensure-admin hook must use ensureadmin" unless ensure_admin_container["command"] == ["python", "manage.py", "ensureadmin"]
+          raise "ospere ensure-admin hook must use syncadmin" unless ensure_admin_container["command"] == ["python", "manage.py", "syncadmin"]
 
           admin_env = ensure_admin_container["env"] || []
           admin_secret_refs = admin_env.each_with_object({}) do |env_var, refs|

--- a/charts/ospere/Chart.yaml
+++ b/charts/ospere/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ospere
 description: Django service for IRS MeF filing orchestration, schema validation, and filing lifecycle state.
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "0.1.0"
 home: https://kungfu.ai
 icon: https://cdn.prod.website-files.com/626ff088dc91e832fe2f3249/680e74ec5378b7b440b03b0c_32x32.png

--- a/charts/ospere/README.md
+++ b/charts/ospere/README.md
@@ -25,8 +25,10 @@ hooks run before normal chart resources, so referencing the chart-created Ospere
 ServiceAccount would break first installs.
 
 The ensure-admin hook is disabled by default. When enabled, it runs after locked
-migrations and reads `DJANGO_ADMIN_USERNAME`, `DJANGO_ADMIN_EMAIL`, and
-`DJANGO_ADMIN_PASSWORD` from `jobs.ensureAdmin.existingSecret`.
+migrations, executes `python manage.py syncadmin`, and reads
+`DJANGO_ADMIN_USERNAME`, `DJANGO_ADMIN_EMAIL`, and `DJANGO_ADMIN_PASSWORD` from
+`jobs.ensureAdmin.existingSecret`. The command creates the admin user if missing
+and rotates the password when the user already exists.
 
 MeF A2A configuration requires more than the mounted certificate. The chart exposes
 the X.509 cert path, private key path, `AppSysID` (`MEF_CLIENT_SYSTEM_ID`), EFIN,

--- a/charts/ospere/templates/jobs.yaml
+++ b/charts/ospere/templates/jobs.yaml
@@ -95,7 +95,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          command: ["python", "manage.py", "ensureadmin"]
+          command: ["python", "manage.py", "syncadmin"]
           {{- include "ospere.environment" . | nindent 10 }}
             {{- include "ospere.serviceComponentEnv" (dict "component" "job.ensure-admin") | nindent 12 }}
             - name: DJANGO_ADMIN_USERNAME


### PR DESCRIPTION
### Scope of changes

Updates the optional Ospere ensure-admin Helm hook to run `python manage.py syncadmin` instead of `ensureadmin`, so chart-driven admin bootstrap uses the same create/update/password-rotation behavior as the kfai-infra workflow.

Bumps the Ospere chart version from `0.1.3` to `0.1.4` and updates the chart README.

### Type of change

- [ ] update app version
- [ ] new objects/feature
- [x] new/additional configuration
- [x] documentation
- [ ] other (describe)

### Author checklist

- [x] I have manually debugged the charts using `helm debug`
- [ ] I have updated any affected `values.schema.json` files
- [x] I have updated the Chart Version for any affected charts

Proof:

- `helm lint charts/ospere`
- `git diff --check`