### PR TITLE
Support plural Ospere MeF client system IDs

### DIFF
--- a/.github/workflows/chart-contract.yaml
+++ b/.github/workflows/chart-contract.yaml
@@ -130,4 +130,58 @@ jobs:
           end
 
           raise "ospere runtime service account missing from rendered chart" if service_account.nil?
+
+          deployment = docs.find do |doc|
+            doc.is_a?(Hash) && doc["kind"] == "Deployment" && doc.dig("metadata", "name") == "ospere"
+          end
+
+          raise "ospere deployment missing from rendered chart" if deployment.nil?
+
+          web_container = deployment.dig("spec", "template", "spec", "containers", 0)
+          raise "ospere web container missing from rendered chart" if web_container.nil?
+
+          web_env = web_container["env"] || []
+          env_by_name = web_env.each_with_object({}) { |env_var, refs| refs[env_var["name"]] = env_var }
+
+          raise "ospere chart must render canonical MEF_CLIENT_SYSTEM_IDS" unless env_by_name.dig("MEF_CLIENT_SYSTEM_IDS", "value") == "client-system,client-system-secondary"
+          raise "ospere chart must preserve compatibility MEF_CLIENT_SYSTEM_ID" unless env_by_name.dig("MEF_CLIENT_SYSTEM_ID", "value") == "client-system"
+          RUBY
+
+          secret_rendered="$(mktemp)"
+          helm template ospere ./charts/ospere \
+            --namespace ospere \
+            --set database.host=postgres.example.com \
+            --set aws.s3.artifactsBucket=ospere-artifacts \
+            --set ospere.mef.cert.secretName=ospere-mef-client-cert-bundle \
+            >"${secret_rendered}"
+
+          ruby - "${secret_rendered}" <<'RUBY'
+          require "yaml"
+
+          path = ARGV.fetch(0)
+          docs = YAML.load_stream(File.read(path))
+          deployment = docs.find do |doc|
+            doc.is_a?(Hash) && doc["kind"] == "Deployment" && doc.dig("metadata", "name") == "ospere"
+          end
+
+          raise "ospere deployment missing from secret-backed rendered chart" if deployment.nil?
+
+          web_container = deployment.dig("spec", "template", "spec", "containers", 0)
+          raise "ospere web container missing from secret-backed rendered chart" if web_container.nil?
+
+          web_env = web_container["env"] || []
+          env_by_name = web_env.each_with_object({}) { |env_var, refs| refs[env_var["name"]] = env_var }
+
+          expected_refs = {
+            "MEF_CLIENT_SYSTEM_IDS" => {"name" => "ospere-mef-client-cert-bundle", "key" => "client_system_ids"},
+            "MEF_CLIENT_SYSTEM_ID" => {"name" => "ospere-mef-client-cert-bundle", "key" => "client_system_id"},
+            "MEF_ETIN" => {"name" => "ospere-mef-client-cert-bundle", "key" => "etin"},
+          }
+
+          expected_refs.each do |name, expected|
+            actual = env_by_name.dig(name, "valueFrom", "secretKeyRef")
+            raise "ospere chart must render #{name} from the MeF cert Secret" unless actual == expected
+          end
+
+          raise "ospere chart must mount the MeF cert Secret" unless web_container["volumeMounts"]&.any? { |mount| mount["name"] == "mef-cert" }
           RUBY

--- a/charts/ospere/Chart.yaml
+++ b/charts/ospere/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ospere
 description: Django service for IRS MeF filing orchestration, schema validation, and filing lifecycle state.
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "0.1.0"
 home: https://kungfu.ai
 icon: https://cdn.prod.website-files.com/626ff088dc91e832fe2f3249/680e74ec5378b7b440b03b0c_32x32.png

--- a/charts/ospere/README.md
+++ b/charts/ospere/README.md
@@ -31,10 +31,18 @@ migrations, executes `python manage.py syncadmin`, and reads
 and rotates the password when the user already exists.
 
 MeF A2A configuration requires more than the mounted certificate. The chart exposes
-the X.509 cert path, private key path, `AppSysID` (`MEF_CLIENT_SYSTEM_ID`), EFIN,
-ETIN, software ID, endpoint, environment, and WSDL paths. The application must also
-read any exposed env vars; at chart introduction time Ospere still needs app-side
-support for `MEF_SOFTWARE_ID`.
+the X.509 cert path, private key path, ordered `AppSysID`/ASID list
+(`MEF_CLIENT_SYSTEM_IDS`), deprecated singular `AppSysID`
+(`MEF_CLIENT_SYSTEM_ID`), EFIN, ETIN, software ID, endpoint, environment, and WSDL
+paths.
+
+`ospere.mef.clientSystemIDs` is rendered as comma-separated
+`MEF_CLIENT_SYSTEM_IDS`. During the compatibility period the chart can also render
+`MEF_CLIENT_SYSTEM_ID`. If `ospere.mef.cert.secretName` is set, the chart can read
+`MEF_CLIENT_SYSTEM_IDS`, `MEF_CLIENT_SYSTEM_ID`, and `MEF_ETIN` from keys in the
+same Kubernetes Secret that mounts the MeF certificate bundle. This keeps
+certificate and MeF account metadata on the same deployment path while the app
+derives the active request AppSysID from the first ordered value.
 
 Environment wiring should provide the public host through chart values. The expected
 GovCIO host pattern is:

--- a/charts/ospere/ci/all-values.yaml
+++ b/charts/ospere/ci/all-values.yaml
@@ -3,6 +3,9 @@ ospere:
   csrfTrustedOrigins: "https://ospere.example.com"
   mef:
     environment: "ats"
+    clientSystemIDs:
+      - "client-system"
+      - "client-system-secondary"
     clientSystemID: "client-system"
     efin: "123456"
     etin: "12345"

--- a/charts/ospere/templates/_environment.tpl
+++ b/charts/ospere/templates/_environment.tpl
@@ -65,9 +65,25 @@ env:
   # MeF
   - name: MEF_ENVIRONMENT
     value: {{ .Values.ospere.mef.environment | quote }}
+  {{- if .Values.ospere.mef.clientSystemIDs }}
+  - name: MEF_CLIENT_SYSTEM_IDS
+    value: {{ join "," .Values.ospere.mef.clientSystemIDs | quote }}
+  {{- else if and .Values.ospere.mef.cert.secretName .Values.ospere.mef.cert.clientSystemIDsKey }}
+  - name: MEF_CLIENT_SYSTEM_IDS
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.ospere.mef.cert.secretName | quote }}
+        key: {{ .Values.ospere.mef.cert.clientSystemIDsKey | quote }}
+  {{- end }}
   {{- if .Values.ospere.mef.clientSystemID }}
   - name: MEF_CLIENT_SYSTEM_ID
     value: {{ .Values.ospere.mef.clientSystemID | quote }}
+  {{- else if and .Values.ospere.mef.cert.secretName .Values.ospere.mef.cert.clientSystemIDKey }}
+  - name: MEF_CLIENT_SYSTEM_ID
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.ospere.mef.cert.secretName | quote }}
+        key: {{ .Values.ospere.mef.cert.clientSystemIDKey | quote }}
   {{- end }}
   {{- if .Values.ospere.mef.efin }}
   - name: MEF_EFIN
@@ -76,6 +92,12 @@ env:
   {{- if .Values.ospere.mef.etin }}
   - name: MEF_ETIN
     value: {{ .Values.ospere.mef.etin | quote }}
+  {{- else if and .Values.ospere.mef.cert.secretName .Values.ospere.mef.cert.etinKey }}
+  - name: MEF_ETIN
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.ospere.mef.cert.secretName | quote }}
+        key: {{ .Values.ospere.mef.cert.etinKey | quote }}
   {{- end }}
   {{- if .Values.ospere.mef.softwareID }}
   - name: MEF_SOFTWARE_ID

--- a/charts/ospere/templates/_helpers.tpl
+++ b/charts/ospere/templates/_helpers.tpl
@@ -91,3 +91,21 @@ default
 {{- define "ospere.image" -}}
 {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
 {{- end -}}
+
+{{- define "ospere.mefCertVolumeMounts" -}}
+{{- if .Values.ospere.mef.cert.secretName }}
+volumeMounts:
+  - name: mef-cert
+    mountPath: {{ .Values.ospere.mef.cert.mountPath | quote }}
+    readOnly: true
+{{- end }}
+{{- end -}}
+
+{{- define "ospere.mefCertVolumes" -}}
+{{- if .Values.ospere.mef.cert.secretName }}
+volumes:
+  - name: mef-cert
+    secret:
+      secretName: {{ .Values.ospere.mef.cert.secretName | quote }}
+{{- end }}
+{{- end -}}

--- a/charts/ospere/templates/celery-beat.yaml
+++ b/charts/ospere/templates/celery-beat.yaml
@@ -53,18 +53,8 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.ospere.mef.cert.secretName }}
-          volumeMounts:
-            - name: mef-cert
-              mountPath: {{ .Values.ospere.mef.cert.mountPath | quote }}
-              readOnly: true
-          {{- end }}
-      {{- if .Values.ospere.mef.cert.secretName }}
-      volumes:
-        - name: mef-cert
-          secret:
-            secretName: {{ .Values.ospere.mef.cert.secretName | quote }}
-      {{- end }}
+          {{- include "ospere.mefCertVolumeMounts" . | nindent 10 }}
+      {{- include "ospere.mefCertVolumes" . | nindent 6 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/ospere/templates/celery-worker.yaml
+++ b/charts/ospere/templates/celery-worker.yaml
@@ -53,18 +53,8 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.ospere.mef.cert.secretName }}
-          volumeMounts:
-            - name: mef-cert
-              mountPath: {{ .Values.ospere.mef.cert.mountPath | quote }}
-              readOnly: true
-          {{- end }}
-      {{- if .Values.ospere.mef.cert.secretName }}
-      volumes:
-        - name: mef-cert
-          secret:
-            secretName: {{ .Values.ospere.mef.cert.secretName | quote }}
-      {{- end }}
+          {{- include "ospere.mefCertVolumeMounts" . | nindent 10 }}
+      {{- include "ospere.mefCertVolumes" . | nindent 6 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/ospere/templates/deployment.yaml
+++ b/charts/ospere/templates/deployment.yaml
@@ -68,18 +68,8 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.ospere.mef.cert.secretName }}
-          volumeMounts:
-            - name: mef-cert
-              mountPath: {{ .Values.ospere.mef.cert.mountPath | quote }}
-              readOnly: true
-          {{- end }}
-      {{- if .Values.ospere.mef.cert.secretName }}
-      volumes:
-        - name: mef-cert
-          secret:
-            secretName: {{ .Values.ospere.mef.cert.secretName | quote }}
-      {{- end }}
+          {{- include "ospere.mefCertVolumeMounts" . | nindent 10 }}
+      {{- include "ospere.mefCertVolumes" . | nindent 6 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/ospere/templates/jobs.yaml
+++ b/charts/ospere/templates/jobs.yaml
@@ -39,18 +39,8 @@ spec:
           command: ["python", "manage.py", "lockedmigrate", "--noinput"]
           {{- include "ospere.environment" . | nindent 10 }}
             {{- include "ospere.serviceComponentEnv" (dict "component" "job.migrate") | nindent 12 }}
-          {{- if .Values.ospere.mef.cert.secretName }}
-          volumeMounts:
-            - name: mef-cert
-              mountPath: {{ .Values.ospere.mef.cert.mountPath | quote }}
-              readOnly: true
-          {{- end }}
-      {{- if .Values.ospere.mef.cert.secretName }}
-      volumes:
-        - name: mef-cert
-          secret:
-            secretName: {{ .Values.ospere.mef.cert.secretName | quote }}
-      {{- end }}
+          {{- include "ospere.mefCertVolumeMounts" . | nindent 10 }}
+      {{- include "ospere.mefCertVolumes" . | nindent 6 }}
       restartPolicy: Never
   backoffLimit: {{ .Values.jobs.migrate.backoffLimit | default 5 }}
 {{- end }}
@@ -113,18 +103,8 @@ spec:
                 secretKeyRef:
                   name: {{ required "jobs.ensureAdmin.existingSecret is required when jobs.ensureAdmin.create is true" .Values.jobs.ensureAdmin.existingSecret | quote }}
                   key: {{ .Values.jobs.ensureAdmin.passwordKey | quote }}
-          {{- if .Values.ospere.mef.cert.secretName }}
-          volumeMounts:
-            - name: mef-cert
-              mountPath: {{ .Values.ospere.mef.cert.mountPath | quote }}
-              readOnly: true
-          {{- end }}
-      {{- if .Values.ospere.mef.cert.secretName }}
-      volumes:
-        - name: mef-cert
-          secret:
-            secretName: {{ .Values.ospere.mef.cert.secretName | quote }}
-      {{- end }}
+          {{- include "ospere.mefCertVolumeMounts" . | nindent 10 }}
+      {{- include "ospere.mefCertVolumes" . | nindent 6 }}
       restartPolicy: Never
   backoffLimit: {{ .Values.jobs.ensureAdmin.backoffLimit | default 5 }}
 {{- end -}}

--- a/charts/ospere/values.yaml
+++ b/charts/ospere/values.yaml
@@ -19,6 +19,7 @@ ospere:
   awsQuerystringExpire: 3600
   mef:
     environment: "ats"
+    clientSystemIDs: []
     clientSystemID: ""
     efin: ""
     etin: ""
@@ -31,6 +32,9 @@ ospere:
       mountPath: "/var/run/ospere/mef"
       certKey: "cert.pem"
       privateKeyKey: "key.pem"
+      clientSystemIDsKey: "client_system_ids"
+      clientSystemIDKey: "client_system_id"
+      etinKey: "etin"
 
 web:
   command: []


### PR DESCRIPTION
### Scope of changes

Updates the Ospere chart to support the canonical plural MeF AppSysID/ASID setting:

- renders `ospere.mef.clientSystemIDs` as comma-separated `MEF_CLIENT_SYSTEM_IDS`
- preserves `MEF_CLIENT_SYSTEM_ID` for compatibility while the app call sites finish moving to plural config
- allows `MEF_CLIENT_SYSTEM_IDS`, `MEF_CLIENT_SYSTEM_ID`, and `MEF_ETIN` to come from the same Kubernetes Secret used for the mounted MeF cert bundle
- factors repeated MeF cert volume/volumeMount wiring into shared chart helpers for web, celery, and hook jobs
- bumps the Ospere chart version to `0.1.5`
- extends chart contract assertions for explicit-value and secret-backed MeF config rendering

### Type of change

- [ ] update app version
- [ ] new objects/feature
- [x] new/additional configuration
- [x] documentation
- [ ] other (describe)

### Author checklist

- [x] I have manually debugged the charts using `helm debug`
- [x] I have updated any affected `values.schema.json` files
- [x] I have updated the Chart Version for any affected charts

Proof:

- `helm lint charts/ospere`
- `for chart in charts/*; do helm lint "$chart"; done`
- `helm template ospere ./charts/ospere --namespace ospere -f ./charts/ospere/ci/all-values.yaml --set jobs.ensureAdmin.create=true --set jobs.ensureAdmin.existingSecret=ospere-admin-bootstrap`
- rendered assertions passed for `MEF_CLIENT_SYSTEM_IDS`, `MEF_CLIENT_SYSTEM_ID`, MeF cert volume mount, and secret-backed `MEF_*` refs

Note: there are no `values.schema.json` files in this repo.
