### PR TITLE
Support Ospere tax-year MeF software IDs

### DIFF
--- a/.github/scripts/validate_chart_contracts.rb
+++ b/.github/scripts/validate_chart_contracts.rb
@@ -7,6 +7,7 @@
 # assertions so CI YAML stays wiring-only.
 
 require "open3"
+require "json"
 require "yaml"
 
 ROOT = File.expand_path("../..", __dir__)
@@ -137,6 +138,11 @@ def validate_ospere_hook_contract!
     raise "ospere chart must render canonical MEF_CLIENT_SYSTEM_IDS"
   end
   raise "ospere chart must preserve compatibility MEF_CLIENT_SYSTEM_ID" unless web_env.dig("MEF_CLIENT_SYSTEM_ID", "value") == "client-system"
+  expected_software_ids = {"2024" => "24024829", "2025" => "25024827", "2026" => "26024828"}
+  unless JSON.parse(web_env.dig("MEF_SOFTWARE_IDS_BY_TAX_YEAR", "value")) == expected_software_ids
+    raise "ospere chart must render canonical MEF_SOFTWARE_IDS_BY_TAX_YEAR"
+  end
+  raise "ospere chart must render MEF_DEFAULT_TAX_YEAR" unless web_env.dig("MEF_DEFAULT_TAX_YEAR", "value") == "2025"
 end
 
 def validate_ospere_secret_backed_env_contract!
@@ -158,7 +164,7 @@ def validate_ospere_secret_backed_env_contract!
       "MEF_CLIENT_SYSTEM_ID" => {"name" => "ospere-mef-client-cert-bundle", "key" => "client_system_id"},
       "MEF_EFIN" => {"name" => "ospere-mef-client-cert-bundle", "key" => "efin"},
       "MEF_ETIN" => {"name" => "ospere-mef-client-cert-bundle", "key" => "etin"},
-      "MEF_SOFTWARE_ID" => {"name" => "ospere-mef-client-cert-bundle", "key" => "software_id"}
+      "MEF_SOFTWARE_IDS_BY_TAX_YEAR" => {"name" => "ospere-mef-client-cert-bundle", "key" => "software_ids_by_tax_year"}
     },
     "ospere chart"
   )

--- a/charts/ospere/Chart.yaml
+++ b/charts/ospere/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ospere
 description: Django service for IRS MeF filing orchestration, schema validation, and filing lifecycle state.
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: "0.1.0"
 home: https://kungfu.ai
 icon: https://cdn.prod.website-files.com/626ff088dc91e832fe2f3249/680e74ec5378b7b440b03b0c_32x32.png

--- a/charts/ospere/README.md
+++ b/charts/ospere/README.md
@@ -33,17 +33,22 @@ and rotates the password when the user already exists.
 MeF A2A configuration requires more than the mounted certificate. The chart exposes
 the X.509 cert path, private key path, ordered `AppSysID`/ASID list
 (`MEF_CLIENT_SYSTEM_IDS`), deprecated singular `AppSysID`
-(`MEF_CLIENT_SYSTEM_ID`), EFIN, ETIN, software ID, endpoint, environment, and WSDL
-paths.
+(`MEF_CLIENT_SYSTEM_ID`), EFIN, ETIN, tax-year SoftwareId map, default tax
+year, endpoint, environment, and WSDL paths.
 
 `ospere.mef.clientSystemIDs` is rendered as comma-separated
 `MEF_CLIENT_SYSTEM_IDS`. During the compatibility period the chart can also render
 `MEF_CLIENT_SYSTEM_ID`. If `ospere.mef.cert.secretName` is set, the chart can read
 `MEF_CLIENT_SYSTEM_IDS`, `MEF_CLIENT_SYSTEM_ID`, `MEF_EFIN`, `MEF_ETIN`, and
-`MEF_SOFTWARE_ID` from keys in the same Kubernetes Secret that mounts the MeF
-certificate bundle. This keeps
+`MEF_SOFTWARE_IDS_BY_TAX_YEAR` from keys in the same Kubernetes Secret that
+mounts the MeF certificate bundle. This keeps
 certificate and MeF account metadata on the same deployment path while the app
 derives the active request AppSysID from the first ordered value.
+
+`ospere.mef.softwareIDsByTaxYear` renders directly as JSON when set in values.
+When `ospere.mef.cert.secretName` is set, the chart reads the JSON value from
+`software_ids_by_tax_year`. `ospere.mef.defaultTaxYear` renders
+`MEF_DEFAULT_TAX_YEAR` for MeF calls that do not carry a request tax year.
 
 When the optional Celery worker is enabled, `worker.concurrency` renders
 `CELERY_WORKER_CONCURRENCY`. The default worker args pass that value to Celery as

--- a/charts/ospere/ci/all-values.yaml
+++ b/charts/ospere/ci/all-values.yaml
@@ -9,7 +9,11 @@ ospere:
     clientSystemID: "client-system"
     efin: "123456"
     etin: "12345"
-    softwareID: "11122233"
+    softwareIDsByTaxYear:
+      "2024": "24024829"
+      "2025": "25024827"
+      "2026": "26024828"
+    defaultTaxYear: "2025"
     endpointURL: "https://example.com/mef"
     cert:
       secretName: "ospere-mef-cert"

--- a/charts/ospere/templates/_environment.tpl
+++ b/charts/ospere/templates/_environment.tpl
@@ -105,15 +105,19 @@ env:
         name: {{ .Values.ospere.mef.cert.secretName | quote }}
         key: {{ .Values.ospere.mef.cert.etinKey | quote }}
   {{- end }}
-  {{- if .Values.ospere.mef.softwareID }}
-  - name: MEF_SOFTWARE_ID
-    value: {{ .Values.ospere.mef.softwareID | quote }}
-  {{- else if and .Values.ospere.mef.cert.secretName .Values.ospere.mef.cert.softwareIDKey }}
-  - name: MEF_SOFTWARE_ID
+  {{- if .Values.ospere.mef.softwareIDsByTaxYear }}
+  - name: MEF_SOFTWARE_IDS_BY_TAX_YEAR
+    value: {{ .Values.ospere.mef.softwareIDsByTaxYear | toJson | quote }}
+  {{- else if and .Values.ospere.mef.cert.secretName .Values.ospere.mef.cert.softwareIDsByTaxYearKey }}
+  - name: MEF_SOFTWARE_IDS_BY_TAX_YEAR
     valueFrom:
       secretKeyRef:
         name: {{ .Values.ospere.mef.cert.secretName | quote }}
-        key: {{ .Values.ospere.mef.cert.softwareIDKey | quote }}
+        key: {{ .Values.ospere.mef.cert.softwareIDsByTaxYearKey | quote }}
+  {{- end }}
+  {{- if .Values.ospere.mef.defaultTaxYear }}
+  - name: MEF_DEFAULT_TAX_YEAR
+    value: {{ .Values.ospere.mef.defaultTaxYear | quote }}
   {{- end }}
   {{- if .Values.ospere.mef.endpointURL }}
   - name: MEF_ENDPOINT_URL

--- a/charts/ospere/values.yaml
+++ b/charts/ospere/values.yaml
@@ -23,7 +23,8 @@ ospere:
     clientSystemID: ""
     efin: ""
     etin: ""
-    softwareID: ""
+    softwareIDsByTaxYear: {}
+    defaultTaxYear: ""
     endpointURL: ""
     msiWSDL: "wsdl/MeFMSIServices.wsdl"
     transmitterWSDL: "wsdl/MeFTransmitterServicesMTOM.wsdl"
@@ -36,7 +37,7 @@ ospere:
       clientSystemIDKey: "client_system_id"
       efinKey: "efin"
       etinKey: "etin"
-      softwareIDKey: "software_id"
+      softwareIDsByTaxYearKey: "software_ids_by_tax_year"
 
 web:
   command: []


### PR DESCRIPTION
### Scope of changes

Updates the Ospere chart to match the app/infra MeF runtime env contract.

- bumps Ospere chart to `0.1.7`
- replaces singular `ospere.mef.softwareID` rendering with `softwareIDsByTaxYear`
- renders `MEF_SOFTWARE_IDS_BY_TAX_YEAR` from values or the MeF cert Secret key `software_ids_by_tax_year`
- renders explicit `MEF_DEFAULT_TAX_YEAR`
- updates chart README and chart contract validation

### Type of change

- [ ] update app version
- [ ] new objects/feature
- [x] new/additional configuration
- [x] documentation
- [ ] other (describe)

### Author checklist

- [x] I have manually debugged the charts using `helm debug`
- [ ] I have updated any affected `values.schema.json` files
- [x] I have updated the Chart Version for any affected charts

### Proof

- `ruby .github/scripts/validate_chart_contracts.rb`

### Merge/deploy note

Merge/publish this chart before deploying the matching Ospere app change. The kfai-infra secret sync PR should also land so the Kubernetes Secret contains `software_ids_by_tax_year` before the app rolls forward.