### PR TITLE
Enable Ospere Celery deployments by default

### DIFF
--- a/.github/scripts/validate_chart_contracts.rb
+++ b/.github/scripts/validate_chart_contracts.rb
@@ -152,6 +152,8 @@ def validate_ospere_secret_backed_env_contract!
     "--namespace", "ospere",
     "--set", "database.host=postgres.example.com",
     "--set", "aws.s3.artifactsBucket=ospere-artifacts",
+    "--set", "secrets.celeryBrokerURL.name=ospere-db",
+    "--set", "secrets.celeryResultBackend.name=ospere-db",
     "--set", "ospere.mef.cert.secretName=ospere-mef-client-cert-bundle"
   )
   deployment = find_doc!(docs, kind: "Deployment", name: "ospere")
@@ -178,8 +180,10 @@ def validate_ospere_worker_contract!
     "ospere",
     "ospere",
     "--namespace", "ospere",
-    "-f", "./charts/ospere/ci/all-values.yaml",
-    "--set", "worker.enabled=true",
+    "--set", "database.host=postgres.example.com",
+    "--set", "aws.s3.artifactsBucket=ospere-artifacts",
+    "--set", "secrets.celeryBrokerURL.name=ospere-db",
+    "--set", "secrets.celeryResultBackend.name=ospere-db",
     "--set", "worker.concurrency=5"
   )
   deployment = find_doc!(docs, kind: "Deployment", name: "ospere-worker")
@@ -190,6 +194,8 @@ def validate_ospere_worker_contract!
   unless (worker_container["args"] || []).include?("--concurrency=$(CELERY_WORKER_CONCURRENCY)")
     raise "ospere worker args must pass CELERY_WORKER_CONCURRENCY to Celery"
   end
+
+  find_doc!(docs, kind: "Deployment", name: "ospere-beat")
 end
 
 begin

--- a/charts/ospere/README.md
+++ b/charts/ospere/README.md
@@ -50,9 +50,13 @@ When `ospere.mef.cert.secretName` is set, the chart reads the JSON value from
 `software_ids_by_tax_year`. `ospere.mef.defaultTaxYear` renders
 `MEF_DEFAULT_TAX_YEAR` for MeF calls that do not carry a request tax year.
 
-When the optional Celery worker is enabled, `worker.concurrency` renders
-`CELERY_WORKER_CONCURRENCY`. The default worker args pass that value to Celery as
+The Celery worker and beat deployments are enabled by default. The worker's
+`worker.concurrency` value renders `CELERY_WORKER_CONCURRENCY`, and the default
+worker args pass that value to Celery as
 `--concurrency=$(CELERY_WORKER_CONCURRENCY)`. The default concurrency is `5`.
+Because worker and beat are enabled by default, deployments must provide
+`secrets.celeryBrokerURL.name` or `secrets.celeryBrokerURL.value`. Worker also
+uses `secrets.celeryResultBackend` when result storage is configured.
 
 Environment wiring should provide the public host through chart values. The expected
 GovCIO host pattern is:

--- a/charts/ospere/values.yaml
+++ b/charts/ospere/values.yaml
@@ -44,7 +44,7 @@ web:
   args: []
 
 worker:
-  enabled: false
+  enabled: true
   replicaCount: 1
   concurrency: 5
   command: ["celery"]
@@ -52,7 +52,7 @@ worker:
   resources: {}
 
 beat:
-  enabled: false
+  enabled: true
   replicaCount: 1
   command: ["celery"]
   args: ["-A", "ospere", "beat", "--loglevel=INFO"]


### PR DESCRIPTION
### Scope of changes

Enable the Ospere chart Celery worker and beat deployments by default so the chart default runtime shape matches the deployed Ospere application model.

This PR:
- changes worker.enabled and beat.enabled defaults to true
- documents the required Celery broker secret configuration now that worker/beat are default-on
- updates chart contract validation to prove default rendering includes ospere-worker and ospere-beat

### Type of change

- [ ] update variables
- [ ] new resources/feature
- [x] new/additional configuration
- [x] documentation
- [ ] other (describe)

### Author checklist

- [x] I have manually debugged the charts using the chart contract validator
- [ ] I have updated any affected tfvars files

Validation:
- ruby .github/scripts/validate_chart_contracts.rb
- git diff --check