### PR TITLE
Fix Ospere chart release version validation

### DIFF
--- a/.github/scripts/validate_chart_release_versions.rb
+++ b/.github/scripts/validate_chart_release_versions.rb
@@ -1,0 +1,92 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Validate that changed charts declare an unreleased chart version.
+#
+# Chart releaser publishes releases as <chart-name>-<chart-version>. If a chart
+# changes without a version bump, the release workflow fails after merge with a
+# GitHub "tag already exists" error. This script moves that invariant into CI.
+
+require "open3"
+require "yaml"
+require "set"
+require "optparse"
+
+ROOT = File.expand_path("../..", __dir__)
+CHARTS_DIR = File.join(ROOT, "charts")
+
+options = {
+  base_ref: ENV["CHART_VERSION_BASE_REF"],
+  head_ref: ENV.fetch("CHART_VERSION_HEAD_REF", "HEAD")
+}
+
+OptionParser.new do |parser|
+  parser.on("--base REF", "Base git ref for changed-file detection") { |value| options[:base_ref] = value }
+  parser.on("--head REF", "Head git ref for changed-file detection") { |value| options[:head_ref] = value }
+end.parse!
+
+def run!(*command)
+  stdout, stderr, status = Open3.capture3(*command, chdir: ROOT)
+  unless status.success?
+    warn stderr
+    raise "#{command.join(' ')} failed"
+  end
+  stdout
+end
+
+def chart_metadata(chart_name)
+  path = File.join(CHARTS_DIR, chart_name, "Chart.yaml")
+  metadata = YAML.safe_load(File.read(path))
+  name = metadata.fetch("name")
+  version = metadata.fetch("version")
+  [name, version]
+end
+
+def changed_chart_names(base_ref, head_ref)
+  raise "base ref is required for chart release version validation" if base_ref.to_s.empty?
+
+  changed_files = run!("git", "diff", "--name-only", "#{base_ref}...#{head_ref}").lines.map(&:strip)
+  changed_files.each_with_object(Set.new) do |path, charts|
+    next unless path.start_with?("charts/")
+
+    _charts_dir, chart_name, = path.split("/", 3)
+    next if chart_name.to_s.empty?
+    next unless File.file?(File.join(CHARTS_DIR, chart_name, "Chart.yaml"))
+
+    charts << chart_name
+  end
+end
+
+def tag_exists?(tag_name)
+  system("git", "rev-parse", "--verify", "--quiet", "refs/tags/#{tag_name}", chdir: ROOT, out: File::NULL)
+end
+
+begin
+  charts = changed_chart_names(options.fetch(:base_ref), options.fetch(:head_ref))
+
+  if charts.empty?
+    puts "no changed charts require release version validation"
+    exit 0
+  end
+
+  failures = []
+  charts.sort.each do |chart_name|
+    release_name, version = chart_metadata(chart_name)
+    tag_name = "#{release_name}-#{version}"
+    if tag_exists?(tag_name)
+      failures << "#{chart_name}: release tag #{tag_name} already exists; bump charts/#{chart_name}/Chart.yaml version"
+    else
+      puts "#{chart_name}: release tag #{tag_name} is available"
+    end
+  end
+
+  unless failures.empty?
+    failures.each { |failure| warn "::error::#{failure}" }
+    exit 1
+  end
+
+  puts "chart release versions ok"
+rescue StandardError => e
+  warn "::error::#{e.message}"
+  exit 1
+end

--- a/.github/workflows/chart-contract.yaml
+++ b/.github/workflows/chart-contract.yaml
@@ -6,6 +6,7 @@ on:
       - 'charts/**/*.yaml'
       - 'charts/**/*.tpl'
       - 'charts/**/templates/**'
+      - '.github/scripts/**/*.rb'
       - '.github/workflows/**/*.yml'
       - '.github/workflows/**/*.yaml'
 
@@ -16,9 +17,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
 
       - name: Validate chart contracts
         run: ruby .github/scripts/validate_chart_contracts.rb
+
+      - name: Validate changed chart release versions
+        run: ruby .github/scripts/validate_chart_release_versions.rb --base "origin/${{ github.base_ref }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,9 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: Validate changed chart release versions
+        run: ruby .github/scripts/validate_chart_release_versions.rb --base "${{ github.event.before }}"
+
       - name: Prepare GPG key
         run: |
           gpg_dir=.cr-gpg

--- a/charts/ospere/Chart.yaml
+++ b/charts/ospere/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ospere
 description: Django service for IRS MeF filing orchestration, schema validation, and filing lifecycle state.
 type: application
-version: 0.1.7
+version: 0.1.8
 appVersion: "0.1.0"
 home: https://kungfu.ai
 icon: https://cdn.prod.website-files.com/626ff088dc91e832fe2f3249/680e74ec5378b7b440b03b0c_32x32.png


### PR DESCRIPTION
### Scope of changes

Fix the Ospere chart release failure from #50 by bumping `charts/ospere/Chart.yaml` to `0.1.8` and adding release-version validation for changed charts.

The new validator checks changed charts against existing git tags and fails before merge/release if `<chart-name>-<chart-version>` already exists.

### Type of change

- [ ] update app version
- [ ] new objects/feature
- [x] new/additional configuration
- [ ] documentation
- [x] other (describe): CI release contract validation

### Author checklist

- [x] I have manually debugged the charts using `helm debug`
- [ ] I have updated any affected `values.schema.json` files
- [x] I have updated the Chart Version for any affected charts

Validation:

- `ruby .github/scripts/validate_chart_release_versions.rb --base origin/main`
- `ruby .github/scripts/validate_chart_contracts.rb`
- `git diff --check origin/main...HEAD`
- negative check: temporary local `ospere-0.1.8` tag causes the release-version validator to fail as expected
