### PR TITLE
Add Ospere API auth chart wiring

### DIFF
--- a/charts/ospere/Chart.yaml
+++ b/charts/ospere/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ospere
 description: Django service for IRS MeF filing orchestration, schema validation, and filing lifecycle state.
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: "0.1.0"
 home: https://kungfu.ai
 icon: https://cdn.prod.website-files.com/626ff088dc91e832fe2f3249/680e74ec5378b7b440b03b0c_32x32.png

--- a/charts/ospere/README.md
+++ b/charts/ospere/README.md
@@ -30,6 +30,15 @@ migrations, executes `python manage.py syncadmin`, and reads
 `jobs.ensureAdmin.existingSecret`. The command creates the admin user if missing
 and rotates the password when the user already exists.
 
+API authentication is controlled by `ospere.apiAuth.mode`. Supported modes are
+`disabled` and `hawk`. `disabled` is intended for local/dev-only use. In deployed
+environments, set `ospere.apiAuth.mode=hawk` and provide
+`ospere.apiAuth.hawk.secretName` with `client_id` and `client_key` keys. The
+chart renders `OSPERE_API_AUTH_MODE`, `HAWK_CLIENT_ID`, `HAWK_CLIENT_KEY`, and
+`HAWK_ALGORITHM` into web, worker, beat, migrate, and ensure-admin workloads.
+When mode is `hawk`, missing Hawk secret references fail chart rendering instead
+of falling back to unauthenticated behavior.
+
 MeF A2A configuration requires more than the mounted certificate. The chart exposes
 the X.509 cert path, private key path, ordered `AppSysID`/ASID list
 (`MEF_CLIENT_SYSTEM_IDS`), deprecated singular `AppSysID`

--- a/charts/ospere/README.md
+++ b/charts/ospere/README.md
@@ -32,9 +32,9 @@ and rotates the password when the user already exists.
 
 API authentication is controlled by `ospere.apiAuth.mode`. Supported modes are
 `disabled` and `hawk`. `disabled` is intended for local/dev-only use. In deployed
-environments, set `ospere.apiAuth.mode=hawk` and provide
-`ospere.apiAuth.hawk.secretName` with `client_id` and `client_key` keys. The
-chart renders `OSPERE_API_AUTH_MODE`, `HAWK_CLIENT_ID`, `HAWK_CLIENT_KEY`, and
+environments, set `ospere.apiAuth.mode=hawk` and provide `ospere.apiAuth.hawk.secretName`.
+By default, the chart reads `client_id` and `client_key` from that Secret (override via
+`ospere.apiAuth.hawk.clientIdKey` / `ospere.apiAuth.hawk.clientKeyKey`). The chart renders `OSPERE_API_AUTH_MODE`, `HAWK_CLIENT_ID`, `HAWK_CLIENT_KEY`, and
 `HAWK_ALGORITHM` into web, worker, beat, migrate, and ensure-admin workloads.
 When mode is `hawk`, missing Hawk secret references fail chart rendering instead
 of falling back to unauthenticated behavior.

--- a/charts/ospere/ci/all-values.yaml
+++ b/charts/ospere/ci/all-values.yaml
@@ -1,6 +1,10 @@
 ospere:
   allowedHosts: "ospere.example.com"
   csrfTrustedOrigins: "https://ospere.example.com"
+  apiAuth:
+    mode: "hawk"
+    hawk:
+      secretName: "ospere-hawk-auth"
   mef:
     environment: "ats"
     clientSystemIDs:

--- a/charts/ospere/templates/_environment.tpl
+++ b/charts/ospere/templates/_environment.tpl
@@ -9,6 +9,21 @@ Ospere pods are configured primarily through environment variables.
 {{- if and .Values.beat.enabled (not $celeryBrokerConfigured) -}}
 {{- fail "beat.enabled requires secrets.celeryBrokerURL.value when secrets.create is true, or secrets.celeryBrokerURL.name when secrets.create is false" -}}
 {{- end -}}
+{{- $apiAuthMode := required "ospere.apiAuth.mode is required" .Values.ospere.apiAuth.mode -}}
+{{- if not (has $apiAuthMode (list "disabled" "hawk")) -}}
+{{- fail "ospere.apiAuth.mode must be one of: disabled, hawk" -}}
+{{- end -}}
+{{- if eq $apiAuthMode "hawk" -}}
+{{- if not .Values.ospere.apiAuth.hawk.secretName -}}
+{{- fail "ospere.apiAuth.hawk.secretName is required when ospere.apiAuth.mode=hawk" -}}
+{{- end -}}
+{{- if not .Values.ospere.apiAuth.hawk.clientIdKey -}}
+{{- fail "ospere.apiAuth.hawk.clientIdKey is required when ospere.apiAuth.mode=hawk" -}}
+{{- end -}}
+{{- if not .Values.ospere.apiAuth.hawk.clientKeyKey -}}
+{{- fail "ospere.apiAuth.hawk.clientKeyKey is required when ospere.apiAuth.mode=hawk" -}}
+{{- end -}}
+{{- end -}}
 env:
   # Django
   - name: DJANGO_SETTINGS_MODULE
@@ -40,6 +55,24 @@ env:
   {{- if .Values.ospere.csrfTrustedOrigins }}
   - name: CSRF_TRUSTED_ORIGINS
     value: {{ .Values.ospere.csrfTrustedOrigins | quote }}
+  {{- end }}
+
+  # API auth
+  - name: OSPERE_API_AUTH_MODE
+    value: {{ $apiAuthMode | quote }}
+  {{- if eq $apiAuthMode "hawk" }}
+  - name: HAWK_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.ospere.apiAuth.hawk.secretName | quote }}
+        key: {{ .Values.ospere.apiAuth.hawk.clientIdKey | quote }}
+  - name: HAWK_CLIENT_KEY
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.ospere.apiAuth.hawk.secretName | quote }}
+        key: {{ .Values.ospere.apiAuth.hawk.clientKeyKey | quote }}
+  - name: HAWK_ALGORITHM
+    value: {{ .Values.ospere.apiAuth.hawk.algorithm | default "sha256" | quote }}
   {{- end }}
 
   # AWS/S3-compatible storage

--- a/charts/ospere/values.yaml
+++ b/charts/ospere/values.yaml
@@ -17,6 +17,13 @@ ospere:
   storageBackend: "s3"
   localStorageRoot: "/app/storage/artifacts"
   awsQuerystringExpire: 3600
+  apiAuth:
+    mode: "disabled"
+    hawk:
+      secretName: ""
+      clientIdKey: "client_id"
+      clientKeyKey: "client_key"
+      algorithm: "sha256"
   mef:
     environment: "ats"
     clientSystemIDs: []

--- a/tests/chart_contract/test_ospere_render_contract.py
+++ b/tests/chart_contract/test_ospere_render_contract.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from chart_contract import (
     assert_secret_refs,
     env_by_name,
@@ -71,6 +73,16 @@ def test_ospere_value_backed_mef_and_celery_contract() -> None:
     )
 
     web_env = env_by_name(first_container(find_doc(docs, kind="Deployment", name="ospere"), "ospere web"))
+    assert web_env["OSPERE_API_AUTH_MODE"]["value"] == "hawk"
+    assert web_env["HAWK_ALGORITHM"]["value"] == "sha256"
+    assert web_env["HAWK_CLIENT_ID"]["valueFrom"]["secretKeyRef"] == {
+        "name": "ospere-hawk-auth",
+        "key": "client_id",
+    }
+    assert web_env["HAWK_CLIENT_KEY"]["valueFrom"]["secretKeyRef"] == {
+        "name": "ospere-hawk-auth",
+        "key": "client_key",
+    }
     assert web_env["MEF_CLIENT_SYSTEM_IDS"]["value"] == "client-system,client-system-secondary"
     assert web_env["MEF_CLIENT_SYSTEM_ID"]["value"] == "client-system"
     assert json.loads(web_env["MEF_SOFTWARE_IDS_BY_TAX_YEAR"]["value"]) == {
@@ -86,11 +98,21 @@ def test_ospere_value_backed_mef_and_celery_contract() -> None:
 
     worker = first_container(find_doc(docs, kind="Deployment", name="ospere-worker"), "ospere worker")
     worker_env = env_by_name(worker)
+    assert worker_env["OSPERE_API_AUTH_MODE"]["value"] == "hawk"
+    assert worker_env["HAWK_CLIENT_ID"]["valueFrom"]["secretKeyRef"] == {
+        "name": "ospere-hawk-auth",
+        "key": "client_id",
+    }
     assert worker_env["OSPERE_SERVICE_COMPONENT"]["value"] == "celery.worker"
     assert worker_env["CELERY_WORKER_CONCURRENCY"]["value"] == "5"
     assert "--concurrency=$(CELERY_WORKER_CONCURRENCY)" in worker["args"]
 
     beat_env = env_by_name(first_container(find_doc(docs, kind="Deployment", name="ospere-beat"), "ospere beat"))
+    assert beat_env["OSPERE_API_AUTH_MODE"]["value"] == "hawk"
+    assert beat_env["HAWK_CLIENT_ID"]["valueFrom"]["secretKeyRef"] == {
+        "name": "ospere-hawk-auth",
+        "key": "client_id",
+    }
     assert beat_env["OSPERE_SERVICE_COMPONENT"]["value"] == "celery.beat"
 
 
@@ -128,3 +150,92 @@ def test_ospere_secret_backed_mef_contract() -> None:
     )
 
     assert any(mount["name"] == "mef-cert" for mount in web_container.get("volumeMounts", []))
+
+
+def test_ospere_api_auth_env_renders_for_hook_jobs() -> None:
+    docs = render_chart(
+        "ospere",
+        "ospere",
+        "--namespace",
+        "ospere",
+        "-f",
+        "./charts/ospere/ci/all-values.yaml",
+        "--set",
+        "jobs.ensureAdmin.create=true",
+        "--set",
+        "jobs.ensureAdmin.existingSecret=ospere-admin-bootstrap",
+    )
+
+    migration_env = env_by_name(first_container(find_doc(docs, kind="Job", name="ospere-migrate"), "ospere migration"))
+    ensure_admin_env = env_by_name(
+        first_container(find_doc(docs, kind="Job", name="ospere-ensure-admin"), "ospere ensure-admin")
+    )
+    for env in (migration_env, ensure_admin_env):
+        assert env["OSPERE_API_AUTH_MODE"]["value"] == "hawk"
+        assert env["HAWK_CLIENT_ID"]["valueFrom"]["secretKeyRef"] == {
+            "name": "ospere-hawk-auth",
+            "key": "client_id",
+        }
+        assert env["HAWK_CLIENT_KEY"]["valueFrom"]["secretKeyRef"] == {
+            "name": "ospere-hawk-auth",
+            "key": "client_key",
+        }
+
+
+def test_ospere_api_auth_disabled_mode_does_not_render_hawk_secret_refs() -> None:
+    docs = render_chart(
+        "ospere",
+        "ospere",
+        "--namespace",
+        "ospere",
+        "--set",
+        "database.host=postgres.example.com",
+        "--set",
+        "aws.s3.artifactsBucket=ospere-artifacts",
+        "--set",
+        "secrets.celeryBrokerURL.name=ospere-db",
+        "--set",
+        "ospere.apiAuth.mode=disabled",
+    )
+
+    web_env = env_by_name(first_container(find_doc(docs, kind="Deployment", name="ospere"), "ospere web"))
+    assert web_env["OSPERE_API_AUTH_MODE"]["value"] == "disabled"
+    assert "HAWK_CLIENT_ID" not in web_env
+    assert "HAWK_CLIENT_KEY" not in web_env
+    assert "HAWK_ALGORITHM" not in web_env
+
+
+def test_ospere_hawk_auth_requires_secret_reference() -> None:
+    with pytest.raises(RuntimeError, match="ospere.apiAuth.hawk.secretName is required"):
+        render_chart(
+            "ospere",
+            "ospere",
+            "--namespace",
+            "ospere",
+            "--set",
+            "database.host=postgres.example.com",
+            "--set",
+            "aws.s3.artifactsBucket=ospere-artifacts",
+            "--set",
+            "secrets.celeryBrokerURL.name=ospere-db",
+            "--set",
+            "ospere.apiAuth.mode=hawk",
+        )
+
+
+def test_ospere_api_auth_rejects_unknown_mode() -> None:
+    with pytest.raises(RuntimeError, match="ospere.apiAuth.mode must be one of: disabled, hawk"):
+        render_chart(
+            "ospere",
+            "ospere",
+            "--namespace",
+            "ospere",
+            "--set",
+            "database.host=postgres.example.com",
+            "--set",
+            "aws.s3.artifactsBucket=ospere-artifacts",
+            "--set",
+            "secrets.celeryBrokerURL.name=ospere-db",
+            "--set",
+            "ospere.apiAuth.mode=maybe",
+        )


### PR DESCRIPTION
### Scope of changes

Adds Ospere chart wiring for the API auth contract used by the app repo Hawk auth work.

- Adds `ospere.apiAuth.mode` with supported values `disabled` and `hawk`.
- Renders `OSPERE_API_AUTH_MODE` for all Ospere workloads.
- When mode is `hawk`, renders `HAWK_CLIENT_ID` and `HAWK_CLIENT_KEY` from Kubernetes Secret refs plus `HAWK_ALGORITHM` as a value.
- Fails Helm rendering when `ospere.apiAuth.mode=hawk` is missing required Hawk secret refs.
- Documents the chart contract and bumps the Ospere chart version to `0.1.9`.

### Type of change

- [ ] update app version
- [ ] new objects/feature
- [x] new/additional configuration
- [x] documentation
- [ ] other (describe)

### Author checklist

- [x] I have manually debugged the charts using `helm debug`
- [x] I have updated any affected tfvars files

No `values.schema.json` exists in this repo, so there was no schema file to update.

Validation:

- `python3 -m pytest tests/chart_contract -q`
- `python3 .github/scripts/validate_chart_release_versions.py --base origin/main`
- `helm lint charts/ospere`
- `helm template ospere ./charts/ospere -f ./charts/ospere/ci/all-values.yaml --set jobs.ensureAdmin.create=true --set jobs.ensureAdmin.existingSecret=ospere-admin-bootstrap --debug >/tmp/ospere-chart-render.yaml`

Redaction note: Hawk client values are not rendered into manifests. The chart emits only Kubernetes `secretKeyRef` name/key references for `HAWK_CLIENT_ID` and `HAWK_CLIENT_KEY`.
