### PR TITLE
ospere: wire outbound status-notification env (ADR-0007)

### DIFF
--- a/.github/workflows/chart-contract.yaml
+++ b/.github/workflows/chart-contract.yaml
@@ -37,3 +37,31 @@ jobs:
 
       - name: Validate changed chart release versions
         run: python3 .github/scripts/validate_chart_release_versions.py --base "origin/${{ github.base_ref }}"
+
+      - name: Install kubeconform
+        run: |
+          curl -sSLf https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin kubeconform
+
+      - name: Validate rendered manifests (kubeconform)
+        # Render contracts assert the fields we thought to check; kubeconform
+        # asserts the rendered manifests are valid against the Kubernetes API
+        # schema (catches a malformed ref or bad object no assertion covers).
+        # Scoped to charts that ship a ci/all-values.yaml fixture (guaranteed
+        # renderable). -ignore-missing-schemas tolerates CRDs (Karpenter, etc.).
+        run: |
+          set -euo pipefail
+          rc=0
+          for chart in charts/*/; do
+            name="$(basename "$chart")"
+            values="${chart}ci/all-values.yaml"
+            if [ ! -f "$values" ]; then
+              echo "skip ${name}: no ci/all-values.yaml fixture"
+              continue
+            fi
+            echo "== kubeconform ${name} =="
+            helm template "$name" "$chart" --namespace "$name" -f "$values" \
+              | kubeconform -strict -summary -ignore-missing-schemas -kubernetes-version 1.29.0 \
+              || rc=1
+          done
+          exit $rc

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .secret
 .DS_store
 *.tgz
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -42,11 +42,17 @@ This repo owns reusable Helm chart artifacts. It does not own app image
 promotion, release manifests, environment-specific deploy state, smoke/canary
 execution, or AWS resource bootstrap.
 
-Pull request CI runs chart contract tests under `tests/chart_contract`:
+Pull request CI runs the clusterless chart test tiers (see
+[`docs/adr/0002`](docs/adr/0002-chart-test-taxonomy-and-ci-contracts.md)):
 
 - lint and render chart fixtures
 - assert chart-level Kubernetes invariants for Ospere and Facture charts
+- validate rendered manifests against the Kubernetes API schema with
+  `kubeconform` (charts with a `ci/all-values.yaml` fixture)
 - assert changed charts use an unreleased `Chart.yaml` version
+
+Install (`ct install` + `helm test`) is deferred and live/deployed proof is owned
+by `kfai-infra`, not this repo.
 
 Pushes to `main` run chart release only:
 

--- a/charts/ospere/Chart.yaml
+++ b/charts/ospere/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ospere
 description: Django service for IRS MeF filing orchestration, schema validation, and filing lifecycle state.
 type: application
-version: 0.1.9
+version: 0.1.10
 appVersion: "0.1.0"
 home: https://kungfu.ai
 icon: https://cdn.prod.website-files.com/626ff088dc91e832fe2f3249/680e74ec5378b7b440b03b0c_32x32.png

--- a/charts/ospere/README.md
+++ b/charts/ospere/README.md
@@ -39,6 +39,21 @@ By default, the chart reads `client_id` and `client_key` from that Secret (overr
 When mode is `hawk`, missing Hawk secret references fail chart rendering instead
 of falling back to unauthenticated behavior.
 
+Outbound status notifications (ADR-0007) are controlled by
+`ospere.notification`. This is the push half of status delivery: pull (the GET
+endpoints) is the default contract, and push is an opt-in convenience, so the
+feature ships dark — `ospere.notification.enabled` defaults to `false` and a
+release promoted without it leaves notifications off. When enabled, provide
+`ospere.notification.url` and `ospere.notification.hmac.secretName`; the chart
+reads `client_id` and `client_secret` from that Secret (override via
+`ospere.notification.hmac.clientIdKey` / `clientSecretKey`) and renders
+`NOTIFICATION_ENABLED`, `NOTIFICATION_URL`, `NOTIFICATION_CLIENT_ID`, and
+`NOTIFICATION_CLIENT_SECRET`. The hmac Secret is synced by infra (Secrets
+Manager to namespace Secret), never created by this chart — the same lifecycle
+as the Hawk credential. When enabled, a missing url or secret reference fails
+chart rendering. `authMode` is hmac-only today; `none` and `bearer` are ADR
+targets that join here when the app reads `NOTIFICATION_AUTH_MODE`.
+
 MeF A2A configuration requires more than the mounted certificate. The chart exposes
 the X.509 cert path, private key path, ordered `AppSysID`/ASID list
 (`MEF_CLIENT_SYSTEM_IDS`), deprecated singular `AppSysID`

--- a/charts/ospere/ci/all-values.yaml
+++ b/charts/ospere/ci/all-values.yaml
@@ -5,6 +5,11 @@ ospere:
     mode: "hawk"
     hawk:
       secretName: "ospere-hawk-auth"
+  notification:
+    enabled: true
+    url: "https://bridge.example.com/v1/integrations/ospere/events"
+    hmac:
+      secretName: "ospere-notification-hmac"
   mef:
     environment: "ats"
     clientSystemIDs:

--- a/charts/ospere/templates/_environment.tpl
+++ b/charts/ospere/templates/_environment.tpl
@@ -24,6 +24,14 @@ Ospere pods are configured primarily through environment variables.
 {{- fail "ospere.apiAuth.hawk.clientKeyKey is required when ospere.apiAuth.mode=hawk" -}}
 {{- end -}}
 {{- end -}}
+{{- if .Values.ospere.notification.enabled -}}
+{{- if not .Values.ospere.notification.url -}}
+{{- fail "ospere.notification.url is required when ospere.notification.enabled=true" -}}
+{{- end -}}
+{{- if not .Values.ospere.notification.hmac.secretName -}}
+{{- fail "ospere.notification.hmac.secretName is required when ospere.notification.enabled=true" -}}
+{{- end -}}
+{{- end -}}
 env:
   # Django
   - name: DJANGO_SETTINGS_MODULE
@@ -73,6 +81,26 @@ env:
         key: {{ .Values.ospere.apiAuth.hawk.clientKeyKey | quote }}
   - name: HAWK_ALGORITHM
     value: {{ .Values.ospere.apiAuth.hawk.algorithm | default "sha256" | quote }}
+  {{- end }}
+
+  # Status notifications (outbound — ADR-0007). ENABLED is always set so the
+  # feature ships dark; url + the infra-synced hmac credential render only when
+  # enabled. The Secret is never chart-created (mirrors apiAuth.hawk).
+  - name: NOTIFICATION_ENABLED
+    value: {{ .Values.ospere.notification.enabled | quote }}
+  {{- if .Values.ospere.notification.enabled }}
+  - name: NOTIFICATION_URL
+    value: {{ .Values.ospere.notification.url | quote }}
+  - name: NOTIFICATION_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.ospere.notification.hmac.secretName | quote }}
+        key: {{ .Values.ospere.notification.hmac.clientIdKey | quote }}
+  - name: NOTIFICATION_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.ospere.notification.hmac.secretName | quote }}
+        key: {{ .Values.ospere.notification.hmac.clientSecretKey | quote }}
   {{- end }}
 
   # AWS/S3-compatible storage

--- a/charts/ospere/templates/_environment.tpl
+++ b/charts/ospere/templates/_environment.tpl
@@ -31,6 +31,12 @@ Ospere pods are configured primarily through environment variables.
 {{- if not .Values.ospere.notification.hmac.secretName -}}
 {{- fail "ospere.notification.hmac.secretName is required when ospere.notification.enabled=true" -}}
 {{- end -}}
+{{- if not .Values.ospere.notification.hmac.clientIdKey -}}
+{{- fail "ospere.notification.hmac.clientIdKey is required when ospere.notification.enabled=true" -}}
+{{- end -}}
+{{- if not .Values.ospere.notification.hmac.clientSecretKey -}}
+{{- fail "ospere.notification.hmac.clientSecretKey is required when ospere.notification.enabled=true" -}}
+{{- end -}}
 {{- end -}}
 env:
   # Django

--- a/charts/ospere/values.yaml
+++ b/charts/ospere/values.yaml
@@ -24,6 +24,19 @@ ospere:
       clientIdKey: "client_id"
       clientKeyKey: "client_key"
       algorithm: "sha256"
+  # Outbound status notifications (ADR-0007). Ships dark: disabled by default,
+  # so promoting a release without setting these leaves the feature off. When
+  # enabled, url + the hmac credential are required. The hmac Secret is synced by
+  # infra (Secrets Manager -> namespace Secret), never created by this chart —
+  # same lifecycle as apiAuth.hawk. authMode is hmac-only today; none/bearer are
+  # ADR targets and join here when the app reads NOTIFICATION_AUTH_MODE.
+  notification:
+    enabled: false
+    url: ""
+    hmac:
+      secretName: ""
+      clientIdKey: "client_id"
+      clientSecretKey: "client_secret"
   mef:
     environment: "ats"
     clientSystemIDs: []

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,34 @@
+# ADR-NNNN: [Short Imperative Title]
+
+**Status:** Proposed | Accepted | Superseded by ADR-NNNN | Deprecated
+**Date:** YYYY-MM-DD
+**Related:** Optional. App-side authority ADR, related chart ADRs, infra ADRs.
+
+## Context
+
+What problem were we solving or what choice was in front of us? What constraints were binding? Keep to 2-4 sentences; link to relevant docs for deeper background. For chart ADRs, name the app-side ADR that owns the behavior — this repo records wiring, not application decisions.
+
+## Decision
+
+What did we choose? One to three sentences. Clean and declarative.
+
+## Consequences
+
+What follows from this decision, honestly? Mix upsides and tradeoffs. What does it commit us to? What does it make harder?
+
+## Implementation Phases
+
+Optional. Use this when the decision intentionally lands across multiple slices.
+Each phase should name the durable output and the condition that closes it.
+
+- **Phase 1 - [name]:** desired state; completion condition.
+- **Phase 2 - [name]:** desired state; completion condition.
+
+## Alternatives Considered
+
+- **Option X:** what it was, why we did not pick it.
+- **Option Y:** what it was, why we did not pick it.
+
+## Related
+
+- Links to relevant docs, prior ADRs, the app-side authority ADR, or pending work this decision depends on.

--- a/docs/adr/0001-ospere-outbound-notification-env-wiring.md
+++ b/docs/adr/0001-ospere-outbound-notification-env-wiring.md
@@ -1,0 +1,75 @@
+# ADR-0001: Ospere Outbound Status-Notification Env Wiring
+
+**Status:** Accepted
+**Date:** 2026-06-15
+**Upstream authority:** [`gcio-irs-mef-service` ADR-0007 — status delivery, pull by default, push optional](https://github.com/kungfuai/gcio-irs-mef-service/tree/dev/docs/adr)
+
+## Context
+
+ADR-0007 in the app repo settles status delivery: pull (the GET endpoints) is
+the contract; push (an outbound webhook) is an opt-in convenience that emits
+thin, signed `Filing.status`-transition events. The app reads four env vars to
+drive push: `NOTIFICATION_ENABLED`, `NOTIFICATION_URL`, `NOTIFICATION_CLIENT_ID`,
+and `NOTIFICATION_CLIENT_SECRET`. The ospere chart had no outbound wiring — only
+the inbound Hawk credential — so this records how the chart exposes push.
+
+This is a chart-side wiring decision, not a re-litigation of pull-vs-push. The
+app ADR remains the authority for the behavior.
+
+## Decision
+
+Add an `ospere.notification` values block and render the four env vars onto the
+web, worker, beat, and hook workloads, mirroring the existing `ospere.apiAuth.hawk`
+block.
+
+```yaml
+ospere:
+  notification:
+    enabled: false
+    url: ""
+    hmac:
+      secretName: ""          # synced by infra; never chart-created
+      clientIdKey: "client_id"
+      clientSecretKey: "client_secret"
+```
+
+1. **Ships dark.** `enabled` defaults to `false`. `NOTIFICATION_ENABLED` is always
+   rendered; `url` and the two `secretKeyRef` vars render only when enabled. A
+   release promoted to any environment without setting these leaves push off,
+   which matches the app default (`parse_notification_config` defaults disabled).
+2. **The hmac credential is infra-synced, never chart-created.** The chart only
+   references `secretName` and reads `client_id` / `client_secret` from it — the
+   same lifecycle as `apiAuth.hawk`: Secrets Manager to namespace Secret via
+   `kfai-infra`, then `secretKeyRef`. Per ADR-0007 the hmac credential reuses the
+   existing Facture/processor-notifier secret, so this is a reference, not a new
+   provisioning ask on the chart.
+3. **Fail loud when enabled.** When `enabled=true`, a missing `url` or
+   `hmac.secretName` fails chart rendering rather than deploying a half-wired,
+   silently-broken emitter.
+4. **Wire only what the app reads.** The app is hmac-only today and does not read
+   `NOTIFICATION_AUTH_MODE`, so the chart does not emit it. `none` / `bearer` are
+   ADR-0007 targets; they join here — as a sibling auth block plus an `authMode`
+   selector — when the app gains the mode surface, in lockstep.
+
+## Consequences
+
+- Promoting Ospere to test/prod is safe with no notification values set: the
+  feature is off. Turning it on later is values-only (set `enabled`, `url`,
+  `hmac.secretName`) with no chart change, once infra has synced the credential.
+- `enabled=true` without a synced Secret fails at render, not at runtime.
+- There is no `BRIDGE_*` legacy to rename: the chart never shipped outbound
+  wiring, so this is purely additive. (Earlier app-side docs referenced
+  `BRIDGE_NOTIFICATION_*`; that name never reached this chart.)
+- Chart version bumped `0.1.9 -> 0.1.10`; merging to `main` publishes it via
+  chart-releaser, and the app release manifest can then pin `0.1.10`.
+
+## Alternatives Considered
+
+- **Source `client_id` as a plain value, only `client_secret` from the Secret.**
+  Rejected: the Hawk block already co-locates id + key in one synced Secret, and
+  keeping the pair together means infra provisions one object. Consistency wins.
+- **Wire `NOTIFICATION_AUTH_MODE` now, defaulting `hmac`.** Rejected for now: the
+  app does not read it, so it would ship a dead env var. Added when the app does.
+- **Chart-managed Secret for the hmac credential.** Rejected: secrets are
+  infra-synced from Secrets Manager across this platform; a chart-created Secret
+  would fork that ownership and risk drift.

--- a/docs/adr/0002-chart-test-taxonomy-and-ci-contracts.md
+++ b/docs/adr/0002-chart-test-taxonomy-and-ci-contracts.md
@@ -1,0 +1,73 @@
+# ADR-0002: Chart Test Taxonomy and CI Contracts
+
+**Status:** Accepted
+**Date:** 2026-06-15
+**Related:** [`gcio-irs-mef-service` ADR-0005 — test taxonomy and CI contracts](https://github.com/kungfuai/gcio-irs-mef-service/tree/dev/docs/adr) (the app-side analogue); [`gcio-irs-mef-service` ADR-0004 — release and deploy contract](https://github.com/kungfuai/gcio-irs-mef-service/tree/dev/docs/adr)
+
+## Context
+
+The app repo names its test tiers explicitly (ADR-0005: fast / contract /
+integration / live) and runs the appropriate clusterless subset on every PR,
+deferring the tiers that need a runtime. This repo had tiers too, but only
+implicitly — the `chart-contract` workflow ran lint + render-contract +
+release-version governance, and the prose "CI/CD Contract" in the README was the
+only record. This ADR names the chart-side taxonomy, states what runs at PR, and
+records what is intentionally deferred or owned elsewhere.
+
+## Decision
+
+Chart proof has four tiers. The first three are clusterless and gate every PR;
+the fourth needs a runtime and is owned by infra.
+
+| tier | what it proves | needs a cluster? | when |
+|---|---|---|---|
+| **lint** | each chart is structurally valid (`helm lint`) | no | PR |
+| **render-contract** | `helm template` produces the exact wiring the app + infra agree on — env names, `secretKeyRef` name/key, hook weights, the cross-boundary shape | no | PR |
+| **schema** | rendered manifests are valid against the Kubernetes API schema (`kubeconform -strict`) — catches malformed objects no hand-written assertion covers | no | PR |
+| **install** | the chart actually installs and its `helm test` hooks pass (`ct install` into kind) | yes (ephemeral) | **deferred** — see below |
+| **live** | a deployed environment has the right image, secrets, DNS, egress (smoke/canary) | yes (real) | **not here** — owned by `kfai-infra` |
+
+Release-version validation (`validate_chart_release_versions.py`) is a governance
+gate, not a test tier: it asserts a changed chart bumped `Chart.yaml` so
+chart-releaser can publish on merge to `main`.
+
+1. **The PR subset is the clusterless tiers: lint + render-contract + schema.**
+   This mirrors the app running fast + contract on PR. `kubeconform` is added to
+   the existing `chart-contract` job, scoped to charts that ship a
+   `ci/all-values.yaml` fixture (the guaranteed-renderable ones), with
+   `-ignore-missing-schemas` so CRD-based charts do not false-fail.
+2. **`live` is intentionally not in this repo.** Per app ADR-0004, deployed-env
+   proof (smoke, canary) belongs to `kfai-infra` for `deployment_scope=ospere`.
+   This repo owns reusable chart artifacts, not environment state.
+3. **`install` (the integration tier) is deferred, not rejected.** The ospere
+   chart already ships `templates/tests/test-connection.yaml` as a `helm test`
+   hook that nothing currently invokes. A `ct install` job into an ephemeral
+   kind cluster + `helm test` is the real analogue of the app's integration
+   tier. It is heavier (spins a cluster per run), so whether it gates every PR or
+   runs pre-merge/nightly is left to a follow-up; this ADR records the gap so it
+   is a decision, not an omission.
+
+## Consequences
+
+- Every PR now proves structural validity, the cross-boundary wiring shape, and
+  Kubernetes-schema validity — without a cluster, so feedback stays fast.
+- `kubeconform` closes the gap between "the fields we asserted" and "the manifest
+  is actually valid," at near-zero cost.
+- The dead `helm test` hook is acknowledged; activating it is the obvious first
+  step if/when the `install` tier lands.
+- The taxonomy is now recorded, so adding a tier (or moving one to nightly) is an
+  explicit amendment rather than ad-hoc CI drift.
+
+## Alternatives Considered
+
+- **Run `kubeconform` as a pytest test that shells out, alongside the render
+  contracts.** Rejected: it would add a `kubeconform` binary dependency to every
+  local `pytest` run. Keeping it a CI step leaves local test runs needing only
+  `helm`, and CI-oriented manifest validation is conventionally a pipeline step.
+- **Validate every chart, including those without `ci/` fixtures.** Rejected:
+  charts without example values (CRD/infra charts like `karpenter-nodepools`)
+  are not reliably renderable without inputs; validating the fixture-backed
+  charts matches what the render contracts already target.
+- **Add `ct install` as a gating PR job now.** Deferred: spinning a kind cluster
+  on every PR is a real cost; decide placement deliberately rather than defaulting
+  it onto the critical path.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,3 +13,4 @@ A chart ADR may reference an app ADR as the upstream authority.
 | ADR | Title |
 |---|---|
 | [0001](0001-ospere-outbound-notification-env-wiring.md) | Ospere outbound status-notification env wiring |
+| [0002](0002-chart-test-taxonomy-and-ci-contracts.md) | Chart test taxonomy and CI contracts |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,15 @@
+# Architecture Decision Records
+
+Decisions that shape the **chart-level contract** in this repo — how charts wire
+env, source secrets, and stay renderable across releases — are recorded here so
+they outlive any single PR.
+
+Scope: these ADRs cover the deployment/wiring surface this repo owns. They do
+**not** re-decide application behavior. App-level decisions live in the app repo
+that owns the image — for Ospere that is
+[`gcio-irs-mef-service/docs/adr`](https://github.com/kungfuai/gcio-irs-mef-service/tree/dev/docs/adr).
+A chart ADR may reference an app ADR as the upstream authority.
+
+| ADR | Title |
+|---|---|
+| [0001](0001-ospere-outbound-notification-env-wiring.md) | Ospere outbound status-notification env wiring |

--- a/tests/chart_contract/test_ospere_render_contract.py
+++ b/tests/chart_contract/test_ospere_render_contract.py
@@ -299,3 +299,49 @@ def test_ospere_notification_enabled_requires_secret_reference() -> None:
             "--set",
             "ospere.notification.url=https://bridge.example.com/events",
         )
+
+
+def test_ospere_notification_enabled_requires_url() -> None:
+    with pytest.raises(RuntimeError, match="ospere.notification.url is required"):
+        render_chart(
+            "ospere",
+            "ospere",
+            "--namespace",
+            "ospere",
+            "--set",
+            "database.host=postgres.example.com",
+            "--set",
+            "aws.s3.artifactsBucket=ospere-artifacts",
+            "--set",
+            "secrets.celeryBrokerURL.name=ospere-db",
+            "--set",
+            "ospere.notification.enabled=true",
+            "--set",
+            "ospere.notification.hmac.secretName=ospere-notification-hmac",
+        )
+
+
+def test_ospere_notification_enabled_requires_non_empty_secret_keys() -> None:
+    # A blanked key would otherwise render secretKeyRef.key: "" — invalid. Mirror
+    # the hawk block, which guards its clientIdKey / clientKeyKey the same way.
+    with pytest.raises(RuntimeError, match="ospere.notification.hmac.clientIdKey is required"):
+        render_chart(
+            "ospere",
+            "ospere",
+            "--namespace",
+            "ospere",
+            "--set",
+            "database.host=postgres.example.com",
+            "--set",
+            "aws.s3.artifactsBucket=ospere-artifacts",
+            "--set",
+            "secrets.celeryBrokerURL.name=ospere-db",
+            "--set",
+            "ospere.notification.enabled=true",
+            "--set",
+            "ospere.notification.url=https://bridge.example.com/events",
+            "--set",
+            "ospere.notification.hmac.secretName=ospere-notification-hmac",
+            "--set",
+            "ospere.notification.hmac.clientIdKey=",
+        )

--- a/tests/chart_contract/test_ospere_render_contract.py
+++ b/tests/chart_contract/test_ospere_render_contract.py
@@ -95,6 +95,18 @@ def test_ospere_value_backed_mef_and_celery_contract() -> None:
         "name": "ospere",
         "key": "celery-broker-url",
     }
+    assert web_env["NOTIFICATION_ENABLED"]["value"] == "true"
+    assert (
+        web_env["NOTIFICATION_URL"]["value"] == "https://bridge.example.com/v1/integrations/ospere/events"
+    )
+    assert web_env["NOTIFICATION_CLIENT_ID"]["valueFrom"]["secretKeyRef"] == {
+        "name": "ospere-notification-hmac",
+        "key": "client_id",
+    }
+    assert web_env["NOTIFICATION_CLIENT_SECRET"]["valueFrom"]["secretKeyRef"] == {
+        "name": "ospere-notification-hmac",
+        "key": "client_secret",
+    }
 
     worker = first_container(find_doc(docs, kind="Deployment", name="ospere-worker"), "ospere worker")
     worker_env = env_by_name(worker)
@@ -106,6 +118,11 @@ def test_ospere_value_backed_mef_and_celery_contract() -> None:
     assert worker_env["OSPERE_SERVICE_COMPONENT"]["value"] == "celery.worker"
     assert worker_env["CELERY_WORKER_CONCURRENCY"]["value"] == "5"
     assert "--concurrency=$(CELERY_WORKER_CONCURRENCY)" in worker["args"]
+    # The worker drains the notification outbox, so it carries the same creds.
+    assert worker_env["NOTIFICATION_CLIENT_SECRET"]["valueFrom"]["secretKeyRef"] == {
+        "name": "ospere-notification-hmac",
+        "key": "client_secret",
+    }
 
     beat_env = env_by_name(first_container(find_doc(docs, kind="Deployment", name="ospere-beat"), "ospere beat"))
     assert beat_env["OSPERE_API_AUTH_MODE"]["value"] == "hawk"
@@ -238,4 +255,47 @@ def test_ospere_api_auth_rejects_unknown_mode() -> None:
             "secrets.celeryBrokerURL.name=ospere-db",
             "--set",
             "ospere.apiAuth.mode=maybe",
+        )
+
+
+def test_ospere_notification_disabled_ships_dark_without_secret_refs() -> None:
+    docs = render_chart(
+        "ospere",
+        "ospere",
+        "--namespace",
+        "ospere",
+        "--set",
+        "database.host=postgres.example.com",
+        "--set",
+        "aws.s3.artifactsBucket=ospere-artifacts",
+        "--set",
+        "secrets.celeryBrokerURL.name=ospere-db",
+    )
+
+    web_env = env_by_name(first_container(find_doc(docs, kind="Deployment", name="ospere"), "ospere web"))
+    # ENABLED is always present (false) so the feature ships dark by default;
+    # nothing else renders, so a promoted release emits no notifications.
+    assert web_env["NOTIFICATION_ENABLED"]["value"] == "false"
+    assert "NOTIFICATION_URL" not in web_env
+    assert "NOTIFICATION_CLIENT_ID" not in web_env
+    assert "NOTIFICATION_CLIENT_SECRET" not in web_env
+
+
+def test_ospere_notification_enabled_requires_secret_reference() -> None:
+    with pytest.raises(RuntimeError, match="ospere.notification.hmac.secretName is required"):
+        render_chart(
+            "ospere",
+            "ospere",
+            "--namespace",
+            "ospere",
+            "--set",
+            "database.host=postgres.example.com",
+            "--set",
+            "aws.s3.artifactsBucket=ospere-artifacts",
+            "--set",
+            "secrets.celeryBrokerURL.name=ospere-db",
+            "--set",
+            "ospere.notification.enabled=true",
+            "--set",
+            "ospere.notification.url=https://bridge.example.com/events",
         )


### PR DESCRIPTION
### Scope of changes

Wires the **outbound status-notification** env onto the `ospere` chart so the push half of ADR-0007 (status delivery, pull-default / push-optional) can be configured per environment. Mirrors the existing `ospere.apiAuth.hawk` block.

- new `ospere.notification` values block (`enabled`, `url`, `hmac.{secretName,clientIdKey,clientSecretKey}`)
- renders `NOTIFICATION_ENABLED` / `NOTIFICATION_URL` / `NOTIFICATION_CLIENT_ID` / `NOTIFICATION_CLIENT_SECRET` onto web/worker/beat/hook workloads via `_environment.tpl`
- **ships dark:** `enabled` defaults to `false`; url + the hmac `secretKeyRef`s render only when enabled, so a promoted release leaves push off (matches the app default in `parse_notification_config`)
- the hmac credential is **infra-synced and referenced by `secretName`, never chart-created** — same lifecycle as the hawk secret
- fail-loud at render when enabled without `url` or `hmac.secretName`
- wires only what the app reads today (hmac-only); `none`/`bearer`/`authMode` join when the app gains the mode surface
- `Chart.yaml` `0.1.9 -> 0.1.10`; extended `ci/all-values.yaml` + contract tests (render asserts, ships-dark, required-secret)
- seeds `docs/adr/` with **ADR-0001** recording the wiring decision (upstream authority is `gcio-irs-mef-service` ADR-0007)

There is no `BRIDGE_*` legacy to rename: the chart never shipped outbound wiring, so this is purely additive.

### Type of change

- [ ] update app version
- [x] new objects/feature
- [x] new/additional configuration
- [x] documentation
- [ ] other (describe)

### Author checklist

- [x] I have manually debugged the charts using `helm debug` (`helm lint` + `helm template` clean; 16 contract tests pass)
- [ ] I have updated any affected `values.schema.json` files (none in this chart)
- [x] I have updated the Chart Version for any affected charts (`0.1.9 -> 0.1.10`)