### PR TITLE
feat(ospere): render MEF_TEST_MODE instead of MEF_ENVIRONMENT

### DIFF
--- a/charts/ospere/Chart.yaml
+++ b/charts/ospere/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ospere
 description: Django service for IRS MeF filing orchestration, schema validation, and filing lifecycle state.
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: "0.1.0"
 home: https://kungfu.ai
 icon: https://cdn.prod.website-files.com/626ff088dc91e832fe2f3249/680e74ec5378b7b440b03b0c_32x32.png

--- a/charts/ospere/README.md
+++ b/charts/ospere/README.md
@@ -58,7 +58,9 @@ MeF A2A configuration requires more than the mounted certificate. The chart expo
 the X.509 cert path, private key path, ordered `AppSysID`/ASID list
 (`MEF_CLIENT_SYSTEM_IDS`), deprecated singular `AppSysID`
 (`MEF_CLIENT_SYSTEM_ID`), EFIN, ETIN, tax-year SoftwareId map, default tax
-year, endpoint, environment, and WSDL paths.
+year, endpoint, test mode, and WSDL paths. `ospere.mef.testMode` (default `true`)
+renders `MEF_TEST_MODE`; `true` sends TestCd "T" to the IRS ATS and `false` is
+production. `ospere.mef.endpointURL` blank falls back to the app's ATS default.
 
 `ospere.mef.clientSystemIDs` is rendered as comma-separated
 `MEF_CLIENT_SYSTEM_IDS`. During the compatibility period the chart can also render

--- a/charts/ospere/ci/all-values.yaml
+++ b/charts/ospere/ci/all-values.yaml
@@ -11,7 +11,7 @@ ospere:
     hmac:
       secretName: "ospere-notification-hmac"
   mef:
-    environment: "ats"
+    testMode: true
     clientSystemIDs:
       - "client-system"
       - "client-system-secondary"

--- a/charts/ospere/templates/_environment.tpl
+++ b/charts/ospere/templates/_environment.tpl
@@ -130,8 +130,8 @@ env:
   {{- end }}
 
   # MeF
-  - name: MEF_ENVIRONMENT
-    value: {{ .Values.ospere.mef.environment | quote }}
+  - name: MEF_TEST_MODE
+    value: {{ .Values.ospere.mef.testMode | quote }}
   {{- if .Values.ospere.mef.clientSystemIDs }}
   - name: MEF_CLIENT_SYSTEM_IDS
     value: {{ join "," .Values.ospere.mef.clientSystemIDs | quote }}

--- a/charts/ospere/values.yaml
+++ b/charts/ospere/values.yaml
@@ -38,7 +38,9 @@ ospere:
       clientIdKey: "client_id"
       clientSecretKey: "client_secret"
   mef:
-    environment: "ats"
+    # test mode (default true) sends TestCd "T" to the IRS ATS; helmfile flips it
+    # to false for production. endpointURL blank falls back to the app's ATS default.
+    testMode: true
     clientSystemIDs: []
     clientSystemID: ""
     efin: ""


### PR DESCRIPTION
## what

the ospere app now owns test-vs-production through a single `MEF_TEST_MODE` bool (companion to the app change in gcio-irs-mef-service#121). this chart was still rendering the retired `MEF_ENVIRONMENT`.

- `_environment.tpl` — render `MEF_TEST_MODE` from `ospere.mef.testMode` (was `MEF_ENVIRONMENT` from `ospere.mef.environment`)
- `values.yaml` — `mef.environment: "ats"` → `mef.testMode: true` (default sends TestCd "T" to the IRS ATS)
- `ci/all-values.yaml`, `README.md` — follow the rename
- `endpointURL` already passes through unchanged; blank falls back to the app's ATS default
- chart bumped 0.1.10 → 0.1.11

## prod wiring

production is flipped to `testMode: false` + the prod A2A host downstream in the kfai-infra helmfile (separate PR). until that lands, every env stays in test mode by default — fail-safe.

renders verified with `helm template -f ci/all-values.yaml`: `MEF_TEST_MODE: "true"` (string, parse_bool-compatible).