### PR TITLE
fix(ospere): env-driven web concurrency and tolerant liveness probe

### DIFF
--- a/charts/ospere/Chart.yaml
+++ b/charts/ospere/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ospere
 description: Django service for IRS MeF filing orchestration, schema validation, and filing lifecycle state.
 type: application
-version: 0.1.11
+version: 0.1.12
 appVersion: "0.1.0"
 home: https://kungfu.ai
 icon: https://cdn.prod.website-files.com/626ff088dc91e832fe2f3249/680e74ec5378b7b440b03b0c_32x32.png

--- a/charts/ospere/templates/deployment.yaml
+++ b/charts/ospere/templates/deployment.yaml
@@ -56,6 +56,14 @@ spec:
               protocol: TCP
           {{- include "ospere.environment" . | nindent 10 }}
             {{- include "ospere.serviceComponentEnv" (dict "component" "web") | nindent 12 }}
+            - name: WEB_CONCURRENCY
+              value: {{ .Values.web.concurrency | quote }}
+            - name: GUNICORN_THREADS
+              value: {{ .Values.web.threads | quote }}
+            - name: GUNICORN_WORKER_CLASS
+              value: {{ .Values.web.workerClass | quote }}
+            - name: GUNICORN_TIMEOUT
+              value: {{ .Values.web.timeout | quote }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/ospere/values.yaml
+++ b/charts/ospere/values.yaml
@@ -64,6 +64,15 @@ ospere:
 web:
   command: []
   args: []
+  # Gunicorn concurrency, surfaced as env into docker/gunicorn.conf.py so the
+  # image bakes no fixed worker count. Threaded (gthread) rather than sync: the
+  # web surface is IO-bound (DB/S3/MeF waits), so threads keep the health probes
+  # served while slow requests are in flight. Bumped above the image default
+  # (2x4); helmfile overrides per environment.
+  concurrency: 4
+  threads: 8
+  workerClass: "gthread"
+  timeout: 60
 
 worker:
   enabled: true
@@ -161,6 +170,12 @@ ingress:
   annotations: {}
   hosts: []
 
+# Liveness must only catch a truly hung process, never a merely busy one — a
+# restart drops in-flight work and makes load worse. The defaults (timeoutSeconds
+# 1, failureThreshold 3) let a couple of slow requests starve the probe and trip a
+# kill; an unset timeout/threshold inherits those. So liveness is deliberately
+# slack: ~60s of unbroken unresponsiveness before a restart. Reacting to load is
+# readiness's job (pull from the endpoints), not liveness's.
 livenessProbe:
   httpGet:
     path: /livez
@@ -170,6 +185,8 @@ livenessProbe:
       value: liveness
   initialDelaySeconds: 2
   periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
 
 readinessProbe:
   httpGet:
@@ -180,6 +197,8 @@ readinessProbe:
       value: readiness
   initialDelaySeconds: 2
   periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
 
 resources: {}
 nodeSelector: {}

--- a/tests/chart_contract/test_ospere_render_contract.py
+++ b/tests/chart_contract/test_ospere_render_contract.py
@@ -107,6 +107,12 @@ def test_ospere_value_backed_mef_and_celery_contract() -> None:
         "name": "ospere-notification-hmac",
         "key": "client_secret",
     }
+    # Gunicorn concurrency is env-driven (docker/gunicorn.conf.py reads these), so
+    # the image bakes no fixed worker count and the chart tunes it per environment.
+    assert web_env["WEB_CONCURRENCY"]["value"] == "4"
+    assert web_env["GUNICORN_THREADS"]["value"] == "8"
+    assert web_env["GUNICORN_WORKER_CLASS"]["value"] == "gthread"
+    assert web_env["GUNICORN_TIMEOUT"]["value"] == "60"
 
     worker = first_container(find_doc(docs, kind="Deployment", name="ospere-worker"), "ospere worker")
     worker_env = env_by_name(worker)
@@ -345,3 +351,23 @@ def test_ospere_notification_enabled_requires_non_empty_secret_keys() -> None:
             "--set",
             "ospere.notification.hmac.clientIdKey=",
         )
+
+
+def test_ospere_web_liveness_is_slack_so_a_busy_pod_is_not_restarted() -> None:
+    # Liveness must catch a hung process, never a merely busy one: a restart drops
+    # in-flight work and worsens load. The k8s defaults (timeoutSeconds 1,
+    # failureThreshold 3) let slow requests starve the probe and trip a kill, so
+    # the chart sets an explicit slack budget (~60s) and leaves load-shedding to
+    # readiness. Pin both so a future edit cannot silently reinstate the defaults.
+    docs = render_chart("ospere", "ospere", "-f", "./charts/ospere/ci/all-values.yaml")
+    web = first_container(find_doc(docs, kind="Deployment", name="ospere"), "ospere web")
+
+    liveness = web["livenessProbe"]
+    assert liveness["httpGet"]["path"] == "/livez"
+    assert liveness["timeoutSeconds"] == 5
+    assert liveness["failureThreshold"] == 6
+
+    readiness = web["readinessProbe"]
+    assert readiness["httpGet"]["path"] == "/readyz"
+    assert readiness["timeoutSeconds"] == 3
+    assert readiness["failureThreshold"] == 3


### PR DESCRIPTION
## what

Make the ospere web tier's gunicorn concurrency env-driven, and loosen the liveness probe so a busy (not dead) pod is no longer restarted.

## why

The test web pod was crash-looping. The liveness probe inherited the k8s defaults (`timeoutSeconds: 1`, `failureThreshold: 3`) — never set in values. When a couple of slow admin requests occupy the gunicorn workers, `/livez` can't be served inside 1s, fails 3×, and the kubelet **restarts a merely-busy pod**. Reacting to load is readiness's job (pull from endpoints), not liveness's.

## how

- `web.{concurrency, threads, workerClass, timeout}` surfaced as env into the web deployment (mirrors how `worker` injects `CELERY_WORKER_CONCURRENCY`). consumed by `docker/gunicorn.conf.py` in the app image — companion PR: gcio-irs-mef-service #126.
- default `gthread`, bumped to **4×8** (above the image default 2×4) for probe headroom.
- **liveness made tolerant**: `timeoutSeconds 5`, `failureThreshold 6` (~60s of unbroken unresponsiveness before a restart). readiness (`3`/`3`) owns load shedding.
- Chart `0.1.11 → 0.1.12`.

## verification

- `helm template` renders web env `4/8/gthread/60` and the tuned probes.
- chart contract tests **12/12 pass** (extended with the web env assertions + a probe-tolerance test that pins the liveness budget so a future edit can't silently reinstate the k8s defaults).

Merge/publish this first so the app build can resolve chart `0.1.12` via the release manifest.
