### PR TITLE
fix(ospere): ingress proxy-body-size 500m for large MeF packets (413 fix)

### DIFF
--- a/charts/ospere/Chart.yaml
+++ b/charts/ospere/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ospere
 description: Django service for IRS MeF filing orchestration, schema validation, and filing lifecycle state.
 type: application
-version: 0.1.12
+version: 0.1.13
 appVersion: "0.1.0"
 home: https://kungfu.ai
 icon: https://cdn.prod.website-files.com/626ff088dc91e832fe2f3249/680e74ec5378b7b440b03b0c_32x32.png

--- a/charts/ospere/values.yaml
+++ b/charts/ospere/values.yaml
@@ -167,7 +167,13 @@ service:
 ingress:
   enabled: false
   className: ""
-  annotations: {}
+  annotations:
+    # MeF packets carry large binary attachments (scanned TIFFs, PDFs); nginx's
+    # default client_max_body_size (1m) rejects them with 413 before they reach
+    # Ospere. Ospere takes artifacts as multipart file parts, so this ingress
+    # limit is the governing one. Bounded by app memory (the return view reads
+    # each file into memory), not set unlimited.
+    nginx.ingress.kubernetes.io/proxy-body-size: "500m"
   hosts: []
 
 # Liveness must only catch a truly hung process, never a merely busy one — a


### PR DESCRIPTION
### Scope of changes

`charts/ospere` — set the ingress `nginx.ingress.kubernetes.io/proxy-body-size` annotation to **`500m`** (default was unset → nginx's default `client_max_body_size` of **1m**), and bump the chart version `0.1.12 → 0.1.13`.

**Why:** MeF packets carry large binary attachments (scanned **TIFFs**, PDFs) that exceed 1 MB, so the ingress returns **413 Request Entity Too Large** before the request ever reaches Ospere. Confirmed live in test — Pedro's 7004 submissions with TIFFs 413'd on `POST /v1/returns`. Ospere receives artifacts as multipart **file parts** (`request.FILES`), so Django's `DATA_UPLOAD_MAX_MEMORY_SIZE` (50 MB) doesn't gate them — the **ingress body limit is the governing one**.

`500m` gives real headroom for TIFF-heavy packets while staying well under the web pod's memory (the return view reads each file into memory), rather than disabling the limit entirely.

This matches a temporary live annotation already applied to the test ingress to unblock Pedro — merging + deploying this just makes it durable (no drift).

### Type of change

- [x] new/additional configuration

### Author checklist

- [ ] I have manually debugged the charts using `helm debug` — annotation renders via the existing `.Values.ingress.annotations` block; no template change
- [ ] I have updated any affected `values.schema.json` files — n/a (annotations is a free-form map)
- [x] I have updated the Chart Version for any affected charts — `0.1.12 → 0.1.13`

### Follow-up (not this PR)

Raised separately: shipping large raw **TIFFs** in the MeF packet means an ever-growing body limit + heavier Ospere memory use — worth converting/compressing (TIFF→PDF) or a pre-signed-URL upload path for very large artifacts rather than only raising the ceiling.
