### PR TITLE
Add opt-in Bedrock batch coordinator deployments to worker chart

### DIFF
--- a/charts/worker/Chart.yaml
+++ b/charts/worker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.3
+version: 0.21.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/worker/ci/all-values.yaml
+++ b/charts/worker/ci/all-values.yaml
@@ -11,3 +11,11 @@ worker:
 secrets:
   notifierClientSecret:
     name: "kfai-testing-notifier"
+# Exercise the opt-in Bedrock batch coordinator templates in CI lint.
+bedrockBatch:
+  enabled: true
+  roleArn: "arn:aws:iam::000000000000:role/kfai-testing-bedrock-batch-inference"
+  classify:
+    enabled: true
+  parse:
+    enabled: true

--- a/charts/worker/templates/_environment.tpl
+++ b/charts/worker/templates/_environment.tpl
@@ -28,6 +28,12 @@ env:
     value: {{ required "aws.sqs.workerQueueURL is required" .Values.aws.sqs.workerQueueURL | quote }}
   - name: SQS_STATUS_QUEUE_URL
     value: {{ required "aws.sqs.statusQueueURL is required" .Values.aws.sqs.statusQueueURL | quote }}
+  {{- if .Values.aws.sqs.resumeQueueURL }}
+  # Optional high-priority queue for resumed (e.g. completed Bedrock batch)
+  # documents. Workers poll it before the main worker queue when set.
+  - name: SQS_WORKER_RESUME_QUEUE_URL
+    value: {{ .Values.aws.sqs.resumeQueueURL | quote }}
+  {{- end }}
   {{- if .Values.aws.endpointUrl }}
   - name: AWS_ENDPOINT_URL
     value: {{ .Values.aws.endpointUrl | quote }}
@@ -100,4 +106,54 @@ env:
   # OpenTelemetry — configured via Instrumentation CRD (auto-instrumentation)
   # The ADOT operator injects OTEL env vars automatically when the pod annotation
   # instrumentation.opentelemetry.io/inject-python: "true" is present.
+{{- end -}}
+
+{{/*
+Extra environment for the Bedrock batch coordinator deployments (classify/parse).
+These run the SAME worker image with a different subcommand and reuse the worker
+env block above (AWS/S3/SQS/DB). This partial only adds the BEDROCK_BATCH_* knobs
+that the `python -m worker bedrock-batch-*` entrypoints read as argument defaults.
+
+Emitted as bare list items (no `env:` header) so it can be appended after
+`worker.environment` at the same indentation, mirroring the ospere pattern.
+
+Call with: (dict "ctx" . "component" "classify"|"parse")
+*/}}
+{{- define "worker.bedrockBatchEnv" -}}
+{{- $ctx := .ctx -}}
+{{- $component := .component -}}
+{{- $b := $ctx.Values.bedrockBatch -}}
+{{- $comp := index $b $component | default dict -}}
+- name: BEDROCK_BATCH_ROLE_ARN
+  value: {{ required "bedrockBatch.roleArn is required when a coordinator is enabled" $b.roleArn | quote }}
+{{- if $b.bucket }}
+- name: BEDROCK_BATCH_BUCKET
+  value: {{ $b.bucket | quote }}
+{{- end }}
+{{- with ($comp.modelId | default $b.modelId) }}
+- name: BEDROCK_BATCH_MODEL_ID
+  value: {{ . | quote }}
+{{- end }}
+- name: BEDROCK_BATCH_MIN_RECORDS
+  value: {{ $b.minRecords | quote }}
+- name: BEDROCK_BATCH_MAX_WAIT_SECONDS
+  value: {{ $b.maxWaitSeconds | quote }}
+# under-minimum policy — see the long note in values.yaml (bedrockBatch.underMinimumPolicy).
+- name: BEDROCK_BATCH_UNDER_MINIMUM_POLICY
+  value: {{ $b.underMinimumPolicy | quote }}
+{{- if eq $component "classify" }}
+- name: BEDROCK_BATCH_CLASSIFY_MAX_RECORDS
+  value: {{ ($comp.maxRecords | default $b.maxRecords) | quote }}
+- name: BEDROCK_BATCH_CLASSIFY_INTERVAL_SECONDS
+  value: {{ ($comp.intervalSeconds | default $b.intervalSeconds) | quote }}
+{{- else if eq $component "parse" }}
+- name: BEDROCK_BATCH_PARSE_MAX_RECORDS
+  value: {{ ($comp.maxRecords | default $b.maxRecords) | quote }}
+- name: BEDROCK_BATCH_PARSE_INTERVAL_SECONDS
+  value: {{ ($comp.intervalSeconds | default $b.intervalSeconds) | quote }}
+{{- if $comp.modelId }}
+- name: BEDROCK_BATCH_PARSE_MODEL_ID
+  value: {{ $comp.modelId | quote }}
+{{- end }}
+{{- end }}
 {{- end -}}

--- a/charts/worker/templates/batch-classify.yaml
+++ b/charts/worker/templates/batch-classify.yaml
@@ -1,0 +1,79 @@
+{{- if and .Values.bedrockBatch.enabled .Values.bedrockBatch.classify.enabled -}}
+{{/*
+Bedrock batch classification coordinator.
+
+Runs the SAME worker image as a separate long-lived process
+(`python -m worker bedrock-batch-classify`). It claims pending BatchClassify
+records from Postgres, stages JSONL to S3, submits/reconciles Bedrock batch
+jobs, and requeues completed documents. Opt-in and off by default; see the
+`bedrockBatch` block in values.yaml.
+*/}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "worker.fullname" . }}-batch-classify
+  labels:
+    {{- include "worker.labels" . | nindent 4 }}
+    app.kubernetes.io/component: batch-classify
+spec:
+  # Coordinator is a singleton submitter/reconciler; DB leasing makes >1 safe
+  # but unnecessary. Keep at 1 unless throughput demands more.
+  replicas: {{ .Values.bedrockBatch.classify.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "worker.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: batch-classify
+  template:
+    metadata:
+      annotations:
+        instrumentation.opentelemetry.io/inject-python: "true"
+        {{- with .Values.pod.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "worker.labels" . | nindent 8 }}
+        app.kubernetes.io/component: batch-classify
+        {{- with .Values.pod.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "worker.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.pod.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}-batch-classify
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            {{- toYaml .Values.bedrockBatch.classify.command | nindent 12 }}
+          args:
+            {{- toYaml .Values.bedrockBatch.classify.args | nindent 12 }}
+          {{- include "worker.environment" . | nindent 10 }}
+            {{- include "worker.bedrockBatchEnv" (dict "ctx" . "component" "classify") | nindent 12 }}
+          {{- with .Values.bedrockBatch.classify.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/worker/templates/batch-parse.yaml
+++ b/charts/worker/templates/batch-parse.yaml
@@ -1,0 +1,80 @@
+{{- if and .Values.bedrockBatch.enabled .Values.bedrockBatch.parse.enabled -}}
+{{/*
+Bedrock batch parse coordinator.
+
+Runs the SAME worker image as a separate long-lived process
+(`python -m worker bedrock-batch-parse`). It claims pending BatchParse records
+from Postgres, stages parser JSONL to S3, submits/reconciles Bedrock batch
+jobs, writes reconciled output back to the document, and requeues completed
+documents. Opt-in and off by default; see the `bedrockBatch` block in
+values.yaml.
+*/}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "worker.fullname" . }}-batch-parse
+  labels:
+    {{- include "worker.labels" . | nindent 4 }}
+    app.kubernetes.io/component: batch-parse
+spec:
+  # Coordinator is a singleton submitter/reconciler; DB leasing makes >1 safe
+  # but unnecessary. Keep at 1 unless throughput demands more.
+  replicas: {{ .Values.bedrockBatch.parse.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "worker.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: batch-parse
+  template:
+    metadata:
+      annotations:
+        instrumentation.opentelemetry.io/inject-python: "true"
+        {{- with .Values.pod.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "worker.labels" . | nindent 8 }}
+        app.kubernetes.io/component: batch-parse
+        {{- with .Values.pod.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "worker.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.pod.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}-batch-parse
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            {{- toYaml .Values.bedrockBatch.parse.command | nindent 12 }}
+          args:
+            {{- toYaml .Values.bedrockBatch.parse.args | nindent 12 }}
+          {{- include "worker.environment" . | nindent 10 }}
+            {{- include "worker.bedrockBatchEnv" (dict "ctx" . "component" "parse") | nindent 12 }}
+          {{- with .Values.bedrockBatch.parse.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/worker/values.yaml
+++ b/charts/worker/values.yaml
@@ -31,6 +31,71 @@ worker:
     waitSeconds: 30
     numWorkers: 1
 
+# Bedrock batch inference coordinators (opt-in, OFF by default).
+#
+# When enabled, two additional Deployments run the SAME worker image with a
+# different subcommand: a classification coordinator and a parse coordinator.
+# They only do work when an experimental pipeline config uses the BatchClassify
+# / BatchParse step classes; the regular worker pipeline is unaffected.
+bedrockBatch:
+  enabled: false
+  # Bedrock batch inference service role passed to CreateModelInvocationJob
+  # (terraform output bedrock_batch_inference_role_arn). Required when enabled.
+  roleArn: ""
+  # S3 bucket for batch JSONL artifacts. Optional; defaults to S3_BUCKET.
+  bucket: ""
+  # Bedrock model or inference profile ID. Optional; the coordinators fall
+  # back to the app's classification/parser model config when unset.
+  modelId: ""
+  # Bedrock's minimum records per batch job.
+  minRecords: 100
+  # Default cap on real records claimed per job (latency + shard-size bound).
+  maxRecords: 100
+  # Oldest-record age before the under-minimum policy applies.
+  maxWaitSeconds: 300
+  # Seconds between coordinator submit/reconcile ticks.
+  intervalSeconds: 30
+  # What to do when maxWaitSeconds expires and the backlog is still under
+  # minRecords:
+  #
+  #   wait_then_on_demand   - fall back to the regular on-demand call for the
+  #                           under-minimum tail. This is the economically
+  #                           honest default: batch only when a REAL backlog
+  #                           reaches the Bedrock minimum, pay on-demand for
+  #                           the trickle. No padding waste.
+  #   wait_then_padded_batch- pad the job to minRecords with dummy records to
+  #                           force batch pricing. Padding is NOT free: it only
+  #                           wins when padding tokens < real tokens, the
+  #                           margin is small even with minimal dummies, and it
+  #                           evaporates if the dummy prompt grows. Treat as an
+  #                           experiment-only knob.
+  #   wait_only             - never fall back or pad; small trickles can stall
+  #                           indefinitely.
+  #
+  # NOTE: this deliberately overrides the app CLI default
+  # (wait_then_padded_batch). Revisit only after Cost Explorer confirms the
+  # batch discount + real minimum for this model/partition.
+  underMinimumPolicy: wait_then_on_demand
+  classify:
+    enabled: false
+    replicaCount: 1
+    command: ["python", "-m", "worker"]
+    args: ["bedrock-batch-classify"]
+    # Optional per-coordinator overrides of modelId/maxRecords/intervalSeconds.
+    modelId: ""
+    maxRecords: ""
+    intervalSeconds: ""
+    resources: {}
+  parse:
+    enabled: false
+    replicaCount: 1
+    command: ["python", "-m", "worker"]
+    args: ["bedrock-batch-parse"]
+    modelId: ""
+    maxRecords: ""
+    intervalSeconds: ""
+    resources: {}
+
 # AWS configuration
 aws:
   region: us-east-2
@@ -39,6 +104,7 @@ aws:
   sqs:
     workerQueueURL: ""
     statusQueueURL: ""
+    resumeQueueURL: ""  # Optional - high-priority resume queue (Bedrock batch)
   endpointUrl: ""  # Optional - for LocalStack/testing only
 
 # Service URLs (Kubernetes DNS)


### PR DESCRIPTION
### Scope of changes

Adds two opt-in Deployments to the `worker` chart for the Bedrock batch coordinators introduced in kungfuai/gcio-irs-tax-form-processor#627: a batch classification coordinator and a batch parse coordinator. Both run the same worker image with a different subcommand (`python -m worker bedrock-batch-classify` / `bedrock-batch-parse`), mirroring the ospere celery worker/beat pattern (values-driven `command`/`args`, `app.kubernetes.io/component` label, shared service account and environment block).

Details:

- `bedrockBatch.*` values block: role ARN, artifact bucket, model ID, min/max records, wait window, tick interval, per-coordinator overrides. Everything is gated behind `bedrockBatch.enabled` plus per-coordinator `enabled` flags and is **OFF by default** — default renders are unchanged except the chart version.
- Under-minimum policy defaults to `wait_then_on_demand` (batch only when a real backlog reaches the Bedrock minimum; fall back to on-demand for the trickle). The values comment documents why padding is an experiment-only knob.
- Optional `aws.sqs.resumeQueueURL` → `SQS_WORKER_RESUME_QUEUE_URL` for the high-priority resume queue (workers poll it before the main queue when set; omitted entirely when unset).
- `ci/all-values.yaml` enables both coordinators so CI lint exercises the new templates.

Note: enabling the coordinators requires a worker image that ships the `bedrock-batch-*` subcommands and batch DB migrations (kungfuai/gcio-irs-tax-form-processor#627), plus the role/queue wiring from the companion kfai-infra PR.

### Type of change

- [ ] update app version
- [x] new objects/feature
- [x] new/additional configuration
- [ ] documentation
- [ ] other (describe)

### Author checklist

- [x] I have manually debugged the charts using `helm debug`
- [ ] I have updated any affected `values.schema.json` files
- [x] I have updated the Chart Version for any affected charts