### PR TITLE
Export custom OTel metrics to the CloudWatch agent OTLP receiver

### DIFF
--- a/charts/extractor/Chart.yaml
+++ b/charts/extractor/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.0
+version: 0.20.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/extractor/templates/_environment.tpl
+++ b/charts/extractor/templates/_environment.tpl
@@ -52,4 +52,18 @@ env:
   # OpenTelemetry — configured via Instrumentation CRD (auto-instrumentation)
   # The ADOT operator injects OTEL env vars automatically when the pod annotation
   # instrumentation.opentelemetry.io/inject-python: "true" is present.
+  #
+  # Custom OTel METRICS need explicit wiring: the operator's default
+  # Instrumentation sets OTEL_METRICS_EXPORTER=none, so app counters (LLM
+  # token usage) are dropped at the SDK. Operator env injection is append-only
+  # — per-pod env set here wins. Points at the CloudWatch agent's OTLP/HTTP
+  # receiver (EMF -> CWAgent namespace); requires the agent OTLP receiver
+  # from kfai-infra. Harmless if the receiver is absent: export fails and
+  # metrics drop, the app is unaffected.
+  {{- if .Values.otelMetrics.enabled }}
+  - name: OTEL_METRICS_EXPORTER
+    value: "otlp"
+  - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+    value: {{ .Values.otelMetrics.endpoint | quote }}
+  {{- end }}
 {{- end -}}

--- a/charts/extractor/values.yaml
+++ b/charts/extractor/values.yaml
@@ -36,6 +36,14 @@ aws:
   s3Bucket: ""  # Required - must be set per environment
   endpointUrl: ""  # Optional - for LocalStack/testing only
 
+# Custom OTel metrics export (LLM token cost counters -> CloudWatch EMF).
+# The CRD-injected auto-instrumentation disables the SDK metrics exporter by
+# default; this re-enables it against the CloudWatch agent's OTLP receiver.
+# Safe to leave on before the receiver exists (export fails silently).
+otelMetrics:
+  enabled: true
+  endpoint: "http://cloudwatch-agent.amazon-cloudwatch:4318/v1/metrics"
+
 # Service account for IRSA (IAM Roles for Service Accounts)
 serviceAccount:
   create: true

--- a/charts/worker/Chart.yaml
+++ b/charts/worker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.21.0
+version: 0.21.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/worker/templates/_environment.tpl
+++ b/charts/worker/templates/_environment.tpl
@@ -106,6 +106,20 @@ env:
   # OpenTelemetry — configured via Instrumentation CRD (auto-instrumentation)
   # The ADOT operator injects OTEL env vars automatically when the pod annotation
   # instrumentation.opentelemetry.io/inject-python: "true" is present.
+  #
+  # Custom OTel METRICS need explicit wiring: the operator's default
+  # Instrumentation sets OTEL_METRICS_EXPORTER=none, so app counters (LLM
+  # token usage) are dropped at the SDK. Operator env injection is append-only
+  # — per-pod env set here wins. Points at the CloudWatch agent's OTLP/HTTP
+  # receiver (EMF -> CWAgent namespace); requires the agent OTLP receiver
+  # from kfai-infra. Harmless if the receiver is absent: export fails and
+  # metrics drop, the app is unaffected.
+  {{- if .Values.otelMetrics.enabled }}
+  - name: OTEL_METRICS_EXPORTER
+    value: "otlp"
+  - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+    value: {{ .Values.otelMetrics.endpoint | quote }}
+  {{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/worker/values.yaml
+++ b/charts/worker/values.yaml
@@ -112,6 +112,14 @@ services:
   extractor:
     url: "http://extractor.facture.svc.cluster.local:8000"
 
+# Custom OTel metrics export (LLM token cost counters -> CloudWatch EMF).
+# The CRD-injected auto-instrumentation disables the SDK metrics exporter by
+# default; this re-enables it against the CloudWatch agent's OTLP receiver.
+# Safe to leave on before the receiver exists (export fails silently).
+otelMetrics:
+  enabled: true
+  endpoint: "http://cloudwatch-agent.amazon-cloudwatch:4318/v1/metrics"
+
 # Service account for IRSA (IAM Roles for Service Accounts)
 serviceAccount:
   create: true


### PR DESCRIPTION
### Scope of changes

Companion to govcio-llc/kfai-infra#165. App-emitted OTel counters (the LLM token cost metric from kungfuai/gcio-irs-tax-form-processor#631) currently die inside the SDK: the addon operator's default Instrumentation sets `OTEL_METRICS_EXPORTER=none` for python pods. Operator env injection is append-only, so per-pod env wins.

- **worker** (0.21.0 → 0.21.1) and **extractor** (0.20.0 → 0.20.1): new `otelMetrics` values block adds `OTEL_METRICS_EXPORTER=otlp` + `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` (CloudWatch agent OTLP/HTTP receiver, EMF → `CWAgent` namespace) to the shared env block. Worker's batch coordinator deployments inherit automatically.
- On by default, gated by `otelMetrics.enabled`. Safe before the agent receiver exists: export fails silently, app unaffected. No per-env values changes needed.

Rollout order: kfai-infra#165 (agent receiver) → chart release → env chart-pin bump.

### Type of change

- [ ] update app version
- [ ] new objects/feature
- [x] new/additional configuration
- [ ] documentation
- [ ] other (describe)

### Author checklist

- [x] I have manually debugged the charts using `helm debug`
- [ ] I have updated any affected `values.schema.json` files
- [x] I have updated the Chart Version for any affected charts