### PR TITLE
Bring OTel metrics export into the deployable chart window

### DIFF
--- a/charts/lander/Chart.yaml
+++ b/charts/lander/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.0
+version: 0.20.1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/lander/templates/_environment.tpl
+++ b/charts/lander/templates/_environment.tpl
@@ -42,4 +42,18 @@ env:
   # OpenTelemetry — configured via Instrumentation CRD (auto-instrumentation)
   # The ADOT operator injects OTEL env vars automatically when the pod annotation
   # instrumentation.opentelemetry.io/inject-python: "true" is present.
+  #
+  # Custom OTel METRICS need explicit wiring: the operator's default
+  # Instrumentation sets OTEL_METRICS_EXPORTER=none, so app counters (LLM
+  # token usage) are dropped at the SDK. Operator env injection is append-only
+  # — per-pod env set here wins. Points at the CloudWatch agent's OTLP/HTTP
+  # receiver (EMF -> CWAgent namespace); requires the agent OTLP receiver
+  # from kfai-infra. Harmless if the receiver is absent: export fails and
+  # metrics drop, the app is unaffected.
+  {{- if .Values.otelMetrics.enabled }}
+  - name: OTEL_METRICS_EXPORTER
+    value: "otlp"
+  - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+    value: {{ .Values.otelMetrics.endpoint | quote }}
+  {{- end }}
 {{- end -}}

--- a/charts/lander/values.yaml
+++ b/charts/lander/values.yaml
@@ -31,6 +31,14 @@ services:
   worker:
     url: "http://worker.facture.svc.cluster.local:8000"
 
+# Custom OTel metrics export (intake latency + request counters -> CloudWatch EMF).
+# The CRD-injected auto-instrumentation disables the SDK metrics exporter by
+# default; this re-enables it against the CloudWatch agent's OTLP receiver.
+# Safe to leave on before the receiver exists (export fails silently).
+otelMetrics:
+  enabled: true
+  endpoint: "http://cloudwatch-agent.amazon-cloudwatch:4318/v1/metrics"
+
 # Service account for IRSA (IAM Roles for Service Accounts)
 serviceAccount:
   create: true

--- a/charts/worker/Chart.yaml
+++ b/charts/worker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.21.1
+version: 0.20.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
## The problem

The release manifest resolves charts with a constraint derived from the **app** version, and picks the newest match at build time:

```python
# generate_release_manifest.py:41
def chart_constraint(release_version: str) -> str:
    return f"~{parts[0]}.{parts[1]}"      # app 0.20.x  ->  "~0.20"
```

Worker moved to `0.21.0` in #59 (batch coordinator deployments), putting it outside that window. #60 then added the OTel metrics export on top as `0.21.1`. Both have been unreachable ever since — `~0.20` cannot select them:

```
constraint ~0.20 returns:     all published:
  0.20.3  <- selected           0.21.1  <- OTel export lives here
  0.20.2                        0.21.0  <- batch coordinators
  0.20.1                        0.20.3  <- what actually deploys
  0.20.0                        ...
```

Live confirms it: sandbox and test both run `worker-0.20.3`. The extractor half of #60 shipped only because its bump landed as `0.20.0 -> 0.20.1`, inside the window.

**Effect in prod today:** the extractor exports `pipeline.tokens.total`, but every worker-side instrument — `pipeline.documents.processed`, `documents.failed`, `document.duration`, `step.duration`, `queue.document.duration` — is computed and then discarded, because the addon operator's default Instrumentation sets `OTEL_METRICS_EXPORTER=none` and nothing overrides it. Verified against the live deployments:

```
extractor   chart 0.20.1   OTEL_METRICS_EXPORTER=otlp     exports
worker      chart 0.20.3   OTEL_METRICS_EXPORTER=<unset>  dropped
lander      chart 0.20.0   OTEL_METRICS_EXPORTER=<unset>  dropped
```

## The change

**worker `0.21.1` -> `0.20.4`.** Rendered against the live test values, the 0.21.x content adds only environment variables — no new Deployments, because the batch coordinators stay gated behind `bedrockBatch.enabled` (`false` by default). That makes it a patch, so `0.21.0` was over-numbered to begin with. Full rendered delta vs deployed `0.20.3`:

```
  helm.sh/chart: worker-0.20.3 -> worker-0.20.4
+ SQS_WORKER_RESUME_QUEUE_URL
+ OTEL_METRICS_EXPORTER=otlp
+ OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
```

`SQS_WORKER_RESUME_QUEUE_URL` appears because the queue already exists from kfai-infra #164. It is safe with batch off: `_receive_next_batch` short-polls the resume queue at `min(1, wait_time)` = 1s before falling through to the normal 20s long poll on the main queue, so an empty resume queue cannot starve it.

**lander `0.20.0` -> `0.20.1`.** Never received the block at all; adding it unblocks `lander.process.duration` and the `http.server.*` metrics. Same ten lines as worker and extractor.

Inspector still lacks the block — low value, left for later.

## Notes

- The `0.21.x` tags are left orphaned but inert: `~0.20` never selects them and nothing references them. When batch is switched on and the app minor moves to 0.21, that is the natural moment to realign all four charts.
- No app change, no infra change, no image rebuild. The next release candidate resolves `worker 0.20.4` and `lander 0.20.1` automatically and carries them through the normal promotion chain.
- `validate_chart_release_versions.py` passes: both tags are available.