### PR TITLE
Export OTel metrics with delta temporality

### DIFF
--- a/charts/extractor/Chart.yaml
+++ b/charts/extractor/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.1
+version: 0.20.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/extractor/templates/_environment.tpl
+++ b/charts/extractor/templates/_environment.tpl
@@ -65,5 +65,12 @@ env:
     value: "otlp"
   - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
     value: {{ .Values.otelMetrics.endpoint | quote }}
+  # Delta temporality is required for CloudWatch: the agent converts cumulative
+  # streams to deltas and discards each stream's first point as the baseline,
+  # which silently swallows low-rate counters (a counter incremented once per
+  # pod lifetime never lands). Delta sums export each interval's increments
+  # directly; a pod death loses at most the final partial interval.
+  - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+    value: "delta"
   {{- end }}
 {{- end -}}

--- a/charts/lander/Chart.yaml
+++ b/charts/lander/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.1
+version: 0.20.2
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/lander/templates/_environment.tpl
+++ b/charts/lander/templates/_environment.tpl
@@ -55,5 +55,12 @@ env:
     value: "otlp"
   - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
     value: {{ .Values.otelMetrics.endpoint | quote }}
+  # Delta temporality is required for CloudWatch: the agent converts cumulative
+  # streams to deltas and discards each stream's first point as the baseline,
+  # which silently swallows low-rate counters (a counter incremented once per
+  # pod lifetime never lands). Delta sums export each interval's increments
+  # directly; a pod death loses at most the final partial interval.
+  - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+    value: "delta"
   {{- end }}
 {{- end -}}

--- a/charts/worker/Chart.yaml
+++ b/charts/worker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.4
+version: 0.20.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/worker/templates/_environment.tpl
+++ b/charts/worker/templates/_environment.tpl
@@ -119,6 +119,13 @@ env:
     value: "otlp"
   - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
     value: {{ .Values.otelMetrics.endpoint | quote }}
+  # Delta temporality is required for CloudWatch: the agent converts cumulative
+  # streams to deltas and discards each stream's first point as the baseline,
+  # which silently swallows low-rate counters (a counter incremented once per
+  # pod lifetime never lands). Delta sums export each interval's increments
+  # directly; a pod death loses at most the final partial interval.
+  - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+    value: "delta"
   {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
## Problem

App counters exported to CloudWatch read 0 even though the SDK was exporting them. Two CloudWatch-side behaviors combine against us:

1. **Cumulative temporality + delta conversion**: the CloudWatch agent converts cumulative OTLP sums to deltas and discards each stream's first datapoint as the conversion baseline. A low-rate counter like `pipeline.documents.processed` (~1 increment per pod/attribute-set lifetime) is swallowed entirely — the only increment becomes the discarded baseline, and every later export is a zero delta. Verified in test: the deploy-time proof run's tokens show zero in CloudWatch (new streams, eaten as baselines) while the next day's run on the same streams shows fine.
2. Pod churn compounds it: increments on a pod that dies before the next 60s flush are lost, and fresh pods start new streams whose first export is again eaten.

Token counters only appeared to work because their streams receive repeated large increments after the initial loss.

## Fix

Set `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta` in the existing `otelMetrics` env block for worker, lander, and extractor. With delta temporality the SDK exports each interval's increments directly — no baseline drop, every increment lands; a pod death loses at most the final partial interval.

No app changes and no new values; the var is emitted only when `otelMetrics.enabled` is set, same as the existing exporter vars.

## Versions

| chart | version |
|---|---|
| worker | 0.20.4 → 0.20.5 |
| lander | 0.20.1 → 0.20.2 |
| extractor | 0.20.1 → 0.20.2 |

All within the `~0.20` release-manifest constraint.

## Verification plan

Rebuild candidate → deploy test → run one processing canary → `pipeline.documents.processed` should register +1 within ~2 minutes (queried via schema-less SEARCH over CWAgent).