### PR TITLE
Let the environment choose the parse recipe

### DIFF
--- a/charts/worker/Chart.yaml
+++ b/charts/worker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.5
+version: 0.20.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/worker/templates/_environment.tpl
+++ b/charts/worker/templates/_environment.tpl
@@ -44,6 +44,10 @@ env:
     value: {{ .Values.services.extractor.url | quote }}
   - name: EXTRACTOR_CONFIG
     value: {{ .Values.worker.extractorConfig | quote }}
+  {{- if .Values.worker.parseRecipe }}
+  - name: PARSE_RECIPE
+    value: {{ .Values.worker.parseRecipe | quote }}
+  {{- end }}
   {{- if .Values.worker.extractorCertPath }}
   - name: EXTRACTOR_CERT_PATH
     value: {{ .Values.worker.extractorCertPath | quote }}

--- a/charts/worker/values.yaml
+++ b/charts/worker/values.yaml
@@ -13,6 +13,10 @@ replicaCount: 1
 
 worker:
   extractorConfig: /app/config/pipeline.yaml
+  # Parse recipe the Parse step runs: "full_schema" or "compact_schema".
+  # Set per environment from kfai-infra; left empty here so the environment is
+  # the only place it is decided. Empty means the env var is not rendered.
+  parseRecipe: ""
   extractorCertPath: ""  # Optional - TLS cert for extractor service
   logLevel: "INFO"
   notifier:


### PR DESCRIPTION
## What

Adds `worker.parseRecipe` to the worker chart, rendered as a `PARSE_RECIPE` env var when set:

```yaml
worker:
  parseRecipe: "compact_schema"   # or "full_schema"; empty = var not rendered
```

Follows the same shape as the model-selection overrides (`models.parserModel` → `PARSER_MODEL`): the environment declares the value in kfai-infra, the chart wires it through, the app obeys it.

## Why

The parse recipe (compact vs full schema) is an environment decision. Today it's baked into the app image via `config/pipeline.yaml`, so changing it per environment means an app release. With this chart value plus the app-side `PARSE_RECIPE` resolution, flipping a single value in kfai-infra and redeploying changes the recipe — infra owns the decision.

## Sequencing

Safe to merge now: with `parseRecipe` unset (the chart default) nothing renders, and until the app reads `PARSE_RECIPE` the variable is ignored. kfai-infra values declaring `compact_schema` for all three environments are prepared and land separately; the app-side resolution is the remaining piece.

## Version

worker 0.20.5 → 0.20.6 (within the `~0.20` manifest constraint). Verified rendered output: var present when set, absent when empty.