### PR TITLE
Add worker.notifier.wireMonikers map rendered to NOTIFIER_WIRE_MONIKERS

### DIFF
--- a/charts/worker/Chart.yaml
+++ b/charts/worker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.6
+version: 0.20.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/worker/ci/all-values.yaml
+++ b/charts/worker/ci/all-values.yaml
@@ -8,6 +8,9 @@ worker:
     enabled: true
     clientID: "kfai-testing-client-id"
     transcriptionURL: "https://example.test/integrations/kungfu-ai/task/transcription"
+    wireMonikers:
+      fbeta_2025: "FBETA_2025_10"
+      falpha_2025_12: "FALPHA_2025_12"
 secrets:
   notifierClientSecret:
     name: "kfai-testing-notifier"

--- a/charts/worker/templates/_environment.tpl
+++ b/charts/worker/templates/_environment.tpl
@@ -76,6 +76,10 @@ env:
     value: {{ $notifier.timeout | default 30 | quote }}
   - name: NOTIFIER_RETRIES
     value: {{ $notifier.retries | default 3 | quote }}
+  {{- if $notifier.wireMonikers }}
+  - name: NOTIFIER_WIRE_MONIKERS
+    value: {{ $notifier.wireMonikers | toJson | quote }}
+  {{- end }}
   {{- if $notifier.clientID }}
   - name: NOTIFIER_CLIENT_ID
     value: {{ $notifier.clientID | quote }}

--- a/charts/worker/values.yaml
+++ b/charts/worker/values.yaml
@@ -28,6 +28,11 @@ worker:
     issueURL: ""
     timeout: 30
     retries: 3
+    # DaaS wire-moniker map: internal schema label -> the exact formMoniker
+    # string Form Bridge's DB expects. Rendered to NOTIFIER_WIRE_MONIKERS as
+    # JSON; empty map omits the env var and the worker emits internal labels
+    # unchanged. Per-environment values own the real map.
+    wireMonikers: {}
   sqs:
     maxRetries: 3
     maxMessages: 1

--- a/tests/chart_contract/test_facture_render_contract.py
+++ b/tests/chart_contract/test_facture_render_contract.py
@@ -38,11 +38,35 @@ def test_worker_chart_contract() -> None:
     assert env["S3_BUCKET"]["value"] == "kfai-testing-cache"
     assert env["SQS_NUM_WORKERS"]["value"] == "1"
     assert env["NOTIFIER_ENABLED"]["value"] == "true"
+    assert env["NOTIFIER_WIRE_MONIKERS"]["value"] == (
+        '{"falpha_2025_12":"FALPHA_2025_12","fbeta_2025":"FBETA_2025_10"}'
+    )
     assert secret_ref(container, "DATABASE_URL") == {"name": "worker", "key": "database-url"}
     assert secret_ref(container, "NOTIFIER_CLIENT_SECRET") == {
         "name": "kfai-testing-notifier",
         "key": "NOTIFIER_CLIENT_SECRET",
     }
+
+
+def test_worker_wire_monikers_env_absent_when_map_empty() -> None:
+    """An empty wireMonikers map must omit NOTIFIER_WIRE_MONIKERS entirely.
+
+    The worker treats an absent env var as passthrough (emit internal labels).
+    Rendering an empty-string or "{}" value instead would change behavior at
+    the app's validator boundary, so absence is the asserted contract.
+    """
+    docs = render_chart(
+        "worker",
+        "worker",
+        "--set",
+        "aws.s3Bucket=b",
+        "--set",
+        "aws.sqs.workerQueueURL=q",
+        "--set",
+        "aws.sqs.statusQueueURL=s",
+    )
+    env = env_by_name(first_container(find_doc(docs, kind="Deployment", name="worker"), "worker"))
+    assert "NOTIFIER_WIRE_MONIKERS" not in env
 
 
 def test_extractor_chart_contract() -> None:


### PR DESCRIPTION
### Scope of changes

`worker` chart only (0.20.6 -> 0.20.7). Adds an optional `worker.notifier.wireMonikers` map that renders to the `NOTIFIER_WIRE_MONIKERS` env var as JSON. The worker (app PR kungfuai/gcio-irs-tax-form-processor#667) uses it to translate internal schema labels to the formMoniker strings Form Bridge expects at the DaaS callback boundary.

Contract:
- empty/absent map omits the env var entirely — the app treats that as passthrough (emit internal labels unchanged), so existing deployments are byte-identical
- `toJson` sorts keys, making the rendered string deterministic; the contract test asserts it exactly
- the real per-environment maps live in kfai-infra values; the chart default is `{}`

New contract tests: exact JSON rendering from the CI fixture (two keys, proves sorting), and absence-when-empty (rendering "" or "{}" instead would change app behavior, so absence is the asserted contract).

### Type of change

- [x] new/additional configuration

### Author checklist

- [x] I have manually debugged the charts using `helm debug`
- [x] I have updated any affected `values.schema.json` files (none exist for this chart)
- [x] I have updated the Chart Version for any affected charts