### PR TITLE
Make replicas optional so kubectl scale does not conflict with helm

### DIFF
--- a/charts/extractor/Chart.yaml
+++ b/charts/extractor/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.2
+version: 0.20.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/extractor/templates/deployment.yaml
+++ b/charts/extractor/templates/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
     {{- include "extractor.labels" . | nindent 4 }}
 spec:
+  {{- if not (kindIs "invalid" .Values.replicaCount) }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   strategy:
     type: {{ .Values.updateStrategy.type }}
     {{- if eq .Values.updateStrategy.type "RollingUpdate" }}

--- a/charts/extractor/values.yaml
+++ b/charts/extractor/values.yaml
@@ -9,6 +9,11 @@
 nameOverride: ""
 fullnameOverride: ""
 
+# Replica count for the Deployment.
+# Set to null to omit .spec.replicas from the rendered Deployment, which
+# leaves replica count unmanaged by helm so kubectl scale or an HPA can own
+# it without conflicting on the next sync. 0 is still rendered (scale to
+# zero); only null omits the field.
 replicaCount: 1
 
 # Deployment update strategy

--- a/charts/lander/Chart.yaml
+++ b/charts/lander/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.2
+version: 0.20.3
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/lander/templates/deployment.yaml
+++ b/charts/lander/templates/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
     {{- include "lander.labels" . | nindent 4 }}
 spec:
+  {{- if not (kindIs "invalid" .Values.replicaCount) }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "lander.selectorLabels" . | nindent 6 }}

--- a/charts/lander/values.yaml
+++ b/charts/lander/values.yaml
@@ -9,6 +9,11 @@
 nameOverride: ""
 fullnameOverride: ""
 
+# Replica count for the Deployment.
+# Set to null to omit .spec.replicas from the rendered Deployment, which
+# leaves replica count unmanaged by helm so kubectl scale or an HPA can own
+# it without conflicting on the next sync. 0 is still rendered (scale to
+# zero); only null omits the field.
 replicaCount: 1
 
 lander:

--- a/charts/worker/Chart.yaml
+++ b/charts/worker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.7
+version: 0.20.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/worker/templates/deployment.yaml
+++ b/charts/worker/templates/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
     {{- include "worker.labels" . | nindent 4 }}
 spec:
+  {{- if not (kindIs "invalid" .Values.replicaCount) }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "worker.selectorLabels" . | nindent 6 }}

--- a/charts/worker/values.yaml
+++ b/charts/worker/values.yaml
@@ -9,6 +9,11 @@
 nameOverride: ""
 fullnameOverride: ""
 
+# Replica count for the Deployment.
+# Set to null to omit .spec.replicas from the rendered Deployment, which
+# leaves replica count unmanaged by helm so kubectl scale or an HPA can own
+# it without conflicting on the next sync. 0 is still rendered (scale to
+# zero); only null omits the field.
 replicaCount: 1
 
 worker:

--- a/tests/chart_contract/test_facture_render_contract.py
+++ b/tests/chart_contract/test_facture_render_contract.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from chart_contract import env_by_name, find_doc, first_container, render_chart, secret_ref
 
+SCALABLE_CHARTS = ("lander", "worker", "extractor")
+
 
 def test_lander_chart_contract() -> None:
     docs = render_chart("lander", "lander", "-f", "./charts/lander/ci/all-values.yaml")
@@ -101,3 +103,55 @@ def test_inspector_chart_contract() -> None:
     assert service["spec"]["ports"][0]["targetPort"] == "http"
     assert ingress["spec"]["ingressClassName"] == "alb"
     assert ingress["spec"]["rules"][0]["host"] == "inspector.example.com"
+
+
+def test_replicas_omitted_when_replica_count_is_null() -> None:
+    """A null replicaCount must omit .spec.replicas from the Deployment.
+
+    Rendering the field is what puts it under helm's field management, so a
+    later `kubectl scale` (throughput profiling) makes kubectl the field manager
+    and the next sync fails with an apply conflict on .spec.replicas. Omitting
+    the field entirely lets helm own the pod spec while kubectl or an HPA owns
+    scaling. Rendering `replicas: null` would not do: the field is still
+    applied, so helm still manages it.
+    """
+    for chart in SCALABLE_CHARTS:
+        docs = render_chart(
+            chart,
+            chart,
+            "-f",
+            f"./charts/{chart}/ci/all-values.yaml",
+            "--set",
+            "replicaCount=null",
+        )
+        deployment = find_doc(docs, kind="Deployment", name=chart)
+
+        assert "replicas" not in deployment["spec"], f"{chart} still renders .spec.replicas"
+
+
+def test_replicas_rendered_when_replica_count_is_set() -> None:
+    """An explicit replicaCount still renders, including the scale-to-zero case.
+
+    Zero is falsy in templates, so a truthiness guard would silently drop it and
+    scale a paused service back to the Kubernetes default of 1. Only an unset
+    value opts out of helm-managed replicas.
+    """
+    for chart in SCALABLE_CHARTS:
+        values = f"./charts/{chart}/ci/all-values.yaml"
+
+        default = find_doc(render_chart(chart, chart, "-f", values), kind="Deployment", name=chart)
+        assert default["spec"]["replicas"] == 1, f"{chart} default replicas changed"
+
+        scaled = find_doc(
+            render_chart(chart, chart, "-f", values, "--set", "replicaCount=3"),
+            kind="Deployment",
+            name=chart,
+        )
+        assert scaled["spec"]["replicas"] == 3, f"{chart} ignored an explicit replicaCount"
+
+        paused = find_doc(
+            render_chart(chart, chart, "-f", values, "--set", "replicaCount=0"),
+            kind="Deployment",
+            name=chart,
+        )
+        assert paused["spec"]["replicas"] == 0, f"{chart} dropped a scale-to-zero replicaCount"


### PR DESCRIPTION
This PR proposes making `.spec.replicas` optional in the lander, worker and extractor deployments so `kubectl scale` no longer conflicts with helm (Fixes #24). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/278. You can sign in with your GitHub ID to claim ownership of the project.

## The defect

All three charts render `.spec.replicas` from `.Values.replicaCount` unconditionally, so helm takes ownership of that field on every sync and there is no way to hand it to `kubectl` or an HPA. Setting `replicaCount` to null does not opt out — the field is still applied, just as an explicit null. On `main` at 6c294e6:

```
$ helm template lander ./charts/lander -f ./charts/lander/ci/all-values.yaml --set replicaCount=null | grep -n '^  replicas:'
50:  replicas:
```

That empty value is `replicas: null` in the applied object, which both keeps the field under helm's field management and resets a hand-scaled deployment to the Kubernetes default of 1.

## The change

`.spec.replicas` is now rendered only when `replicaCount` is non-null, in `charts/{lander,worker,extractor}/templates/deployment.yaml`. Omitting the field is what actually releases it, so helm keeps the pod spec and `kubectl` or an HPA can own scaling without a conflict on the next sync — no more `sed 's/manager: kubectl/manager: helm/g'` pre-sync step.

One deliberate difference from the shape sketched in the issue: the guard tests for null (`if not (kindIs "invalid" .Values.replicaCount)`) rather than truthiness. A bare `if .Values.replicaCount` would also drop `replicas: 0`, since zero is falsy in templates, and silently scale a deliberately paused service back up to 1. Testing for null keeps scale-to-zero working.

Backward compatibility: the defaults are untouched (`replicaCount: 1` in all three `values.yaml`), so every existing release renders byte-identical output. Only a chart consumer who explicitly sets `replicaCount: null` gets the new behavior, and the values files document that opt-out. Chart versions are bumped per the repo's release contract — lander and extractor to 0.20.3, worker to 0.20.8, staying on the 0.20.x line #61 moved back to.

## Verification

Two contract tests are added to `tests/chart_contract/test_facture_render_contract.py`: one asserting a null `replicaCount` omits `.spec.replicas` for all three charts, one asserting the default, an explicit `3` and the scale-to-zero `0` all still render. Reverting only the three template hunks turns the first one red, which is the defect above:

```
E   AssertionError: lander still renders .spec.replicas
E   assert 'replicas' not in {'replicas': None, 'selector': {...}}
```

The full contract suite was run on a clean checkout of `main` before the change (20 passed) and after it (22 passed) with no new failures, alongside `helm lint` on all eight charts, `validate_chart_release_versions.py` against `main`, and `kubeconform -strict` on every chart with a `ci/all-values.yaml` fixture — including a second kubeconform pass rendering lander, worker and extractor with `--set replicaCount=null` to check the new opt-out path produces valid manifests.

## How this was managed

This work was tracked on https://eastagiletracker.com/projects/278/stories/166230, on a board imported from this repository's own issues and pull requests (61 stories) — your open issues are in the current iteration and your merged PRs make up the done column.

![board](https://raw.githubusercontent.com/eastagiletracker/gcio-irs-helm-charts/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
